### PR TITLE
Add auto commit functionality to stores and ec after operations, fix initial gitignore 

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -85,8 +85,24 @@ pub fn default_project_config(use_git: bool) -> String {
 guid = "{guid}"
 # default verbosity level
 verbosity = "error"
+
+[git]
 # whether to integrate with Git
+# turning this off causes all git operations, including adding paths added to Xvc to be added to `.gitignore` or staging committing to Git after Xvc operations to be turned off.
+# not recommended unless you're really not using Git
 use_git = {use_git}
+# git command to use when running git.
+# set this to an absolute path to specify an executable
+# if set to a non-absolute path, it will be searched in $PATH and run.
+command = "git"
+
+# commit any changes in .xvc/ directory after the commands
+# you can handle git manually
+auto_commit = true
+
+# stage any changes in .xvc/ directory without committing
+# if you want to commit after multiple Xvc commands, but don't want to stage after each operation you can turn auto-commit off and turn auto-stage on.
+auto_stage = false
 
 [cache]
 # The cache type for XVC. It may take copy, hardlink, softlink, reflink as values

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,13 +61,14 @@ pub const XVCIGNORE_INITIAL_CONTENT: &str = "
 /// This is not expected to change for some time.
 pub const GIT_DIR: &str = ".git";
 
-/// The initial content for `.xvc/.gitignore` to hide Xvc fs structures
+/// The initial content for `.xvc/.gitignore` to hide files in .xvc/
 ///
-/// Note that most elements are not hidden.
+/// We ignore all, and just track the store, entity counter and the configuration
 pub const GITIGNORE_INITIAL_CONTENT: &str = "
-/config.local
-/tmp
-/cache
+.xvc/*
+!.xvc/store/
+!.xvc/ec/
+!.xvc/config.toml
 ";
 
 /// Creates a new project configuration by writing all default values.

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -147,7 +147,7 @@ impl XvcRoot {
                     let xvcignore_path = path.join(XVCIGNORE_FILENAME);
                     fs::write(xvcignore_path, XVCIGNORE_INITIAL_CONTENT)?;
 
-                    let use_git = config.get_bool("core.use_git")?.option;
+                    let use_git = config.get_bool("git.use_git")?.option;
                     if use_git {
                         let gitignore_path = path.join(&PathBuf::from(".gitignore"));
                         fs::write(gitignore_path, GITIGNORE_INITIAL_CONTENT)?;

--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -18,6 +18,8 @@ use crossbeam_channel::bounded;
 use crossbeam_channel::Sender;
 use fetch::FetchCLI;
 use list::ListCLI;
+use log::info;
+use log::warn;
 use log::{error, LevelFilter};
 use std::io;
 use std::io::Write;
@@ -203,10 +205,10 @@ pub fn dispatch(cli_opts: XvcFileCLI) -> Result<()> {
             while let Ok(output_line) = output_rec.recv() {
                 match output_line {
                     XvcOutputLine::Output(m) => writeln!(output, "{}", m).unwrap(),
-                    XvcOutputLine::Info(m) => writeln!(output, "[INFO] {}", m).unwrap(),
-                    XvcOutputLine::Warn(m) => writeln!(output, "[WARN] {}", m).unwrap(),
-                    XvcOutputLine::Error(m) => writeln!(output, "[ERROR] {}", m).unwrap(),
-                    XvcOutputLine::Panic(m) => writeln!(output, "[PANIC] {}", m).unwrap(),
+                    XvcOutputLine::Info(m) => info!("[INFO] {}", m),
+                    XvcOutputLine::Warn(m) => warn!("[WARN] {}", m),
+                    XvcOutputLine::Error(m) => error!("[ERROR] {}", m),
+                    XvcOutputLine::Panic(m) => panic!("[PANIC] {}", m),
                     XvcOutputLine::Tick(_) => {}
                 }
             }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -68,6 +68,7 @@ relative-path = { version = "^1.5", features = ["serde"] }
 path-absolutize = "^3.0"
 glob = "^0.3"
 fs_extra = "^1.2"
+which = "^4.3"
 
 ## Logging and errors
 thiserror = "^1.0"

--- a/lib/src/cli/mod.rs
+++ b/lib/src/cli/mod.rs
@@ -334,7 +334,7 @@ fn handle_git_automation(xvc_root: &XvcRoot, xvc_cmd: &str) -> Result<()> {
 
             // Add and commit `.xvc`
             let xvc_dir = xvc_root.xvc_dir().to_str().unwrap();
-            let res_git_add = exec_git(&["add", &xvc_dir])?;
+            let res_git_add = exec_git(&["add", &xvc_dir, "*.gitignore", "*.xvcignore"])?;
             info!("Adding .xvc/ to git: {res_git_add}");
             let res_git_commit = exec_git(&[
                 "commit",
@@ -351,7 +351,7 @@ fn handle_git_automation(xvc_root: &XvcRoot, xvc_cmd: &str) -> Result<()> {
                 info!("Unstashed user staged files: {res_git_stash_pop}");
             } else if config.get_bool("git.auto-stage")?.option {
                 let xvc_dir = xvc_root.xvc_dir().to_str().unwrap();
-                let res_git_add = exec_git(&["add", xvc_dir])?;
+                let res_git_add = exec_git(&["add", xvc_dir, "*.gitignore", "*.xvcignore"])?;
                 info!("Staging .xvc/ to git: {res_git_add}");
             }
         }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -51,6 +51,12 @@ pub enum Error {
         source: xvc_walker::error::Error,
     },
 
+    #[error("Configuration Error: {source}")]
+    ConfigError {
+        #[from]
+        source: xvc_config::error::Error,
+    },
+
     #[error("Storage Error: {source}")]
     StorageError {
         #[from]
@@ -99,6 +105,11 @@ pub enum Error {
     CannotParseInteger {
         #[from]
         source: ParseIntError,
+    },
+    #[error("Cannot Find Executable: {source}")]
+    WhichError {
+        #[from]
+        source: which::Error,
     },
 }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -111,6 +111,9 @@ pub enum Error {
         #[from]
         source: which::Error,
     },
+
+    #[error("Git Process Error: \nSTDOUT: {stdout}\nSTDERR: {stderr}")]
+    GitProcessError { stdout: String, stderr: String },
 }
 
 impl Error {

--- a/lib/src/init/mod.rs
+++ b/lib/src/init/mod.rs
@@ -64,7 +64,7 @@ pub fn run(xvc_root_opt: Option<&XvcRoot>, opts: InitCLI) -> Result<XvcRoot> {
             }
         }
         None => {
-            info!("No previous installation found in {:?}", path);
+            info!("No previous repository found in {:?}", path);
         }
     }
 
@@ -79,7 +79,7 @@ pub fn run(xvc_root_opt: Option<&XvcRoot>, opts: InitCLI) -> Result<XvcRoot> {
             }
         }
         Some(git_root) => {
-            info!("Git installation found in: {:?}", git_root);
+            info!("Git repository found in: {:?}", git_root);
         }
     }
     let default_configuration = default_project_config(!opts.no_git);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -28,7 +28,7 @@ pub fn dispatch(args: Vec<&str>) -> Result<()> {
         args
     };
 
-    let cli_opts = cli::XvcCLI::parse_from(args_with_binary_name);
+    let cli_opts = cli::XvcCLI::from_str_slice(&args_with_binary_name)?;
 
     cli::dispatch(cli_opts)
 }
@@ -51,7 +51,7 @@ pub fn test_dispatch(
         args
     };
 
-    let cli_opts = cli::XvcCLI::parse_from(args_with_binary_name);
+    let cli_opts = cli::XvcCLI::from_str_slice(&args_with_binary_name)?;
     watch!(cli_opts);
 
     cli::test_dispatch(xvc_root_opt, cli_opts, verbosity)

--- a/workflow_tests/tests/test_file_track_serial.rs
+++ b/workflow_tests/tests/test_file_track_serial.rs
@@ -178,5 +178,17 @@ fn test_file_track_serial() -> Result<()> {
         "{gs_xvc:?} shouldn't contain any `.xvc/` lines."
     );
 
+    let gs_gitignore = line_captures(&git_status_res, r#".* \.gitignore"#);
+    assert!(
+        gs_gitignore.is_empty(),
+        "{gs_gitignore:?} shouldn't contain any `.gitignore` lines."
+    );
+
+    let gs_xvcignore = line_captures(&git_status_res, r#".* \.xvcignore"#);
+    assert!(
+        gs_xvcignore.is_empty(),
+        "{gs_xvcignore:?} shouldn't contain any `.xvcignore` lines."
+    );
+
     Ok(())
 }

--- a/workflow_tests/tests/test_file_track_serial.rs
+++ b/workflow_tests/tests/test_file_track_serial.rs
@@ -7,6 +7,7 @@ use std::{fs, path::PathBuf};
 use crate::common::{run_in_example_xvc, run_in_temp_xvc_dir};
 use jwalk;
 use regex::Regex;
+use subprocess::Exec;
 use xvc::error::{Error, Result};
 use xvc::{test_dispatch, watch};
 use xvc_config::XvcVerbosity;
@@ -23,6 +24,11 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
     create_directory_tree(&level_1, 10, 10)?;
 
     Ok(temp_dir)
+}
+
+fn sh(cmd: String) -> String {
+    watch!(cmd);
+    Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
 #[test]
@@ -162,6 +168,15 @@ fn test_file_track_serial() -> Result<()> {
     assert!(data_line[0].len() > 0, "{}", data_line[0]);
 
     // todo!("Test different types of cache (symlink, hardlink, copy, reflink");
+
+    //
+
+    let git_status_res = sh("git status -s".to_string());
+    let gs_xvc = line_captures(&git_status_res, r#".* \.xvc/.*"#);
+    assert!(
+        gs_xvc.is_empty(),
+        "{gs_xvc:?} shouldn't contain any `.xvc/` lines."
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds two options to `config` and moves `core.use_git` to `git.use_git`. 

- `git.auto_commit`: Commits Xvc related files after the operations if `true` (default: true)
- `git.auto_stage`: Stages Xvc related files after the operations if `true` (default: false)

