### PR TITLE
add xvc storage new rsync command and related tests

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -62,6 +62,7 @@ reflink = "^0.1"
 relative-path = { version = "^1.5", features = ["serde"] }
 path-absolutize = "^3.0"
 glob = "^0.3"
+which = "^4.3"
 
 ## Logging and errors
 thiserror = "^1.0"

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -71,6 +71,15 @@ pub enum Error {
         source: subprocess::PopenError,
     },
 
+    #[error("Process Error.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}")]
+    ProcessError { stdout: String, stderr: String },
+
+    #[error("Cannot Find Executable: {source}")]
+    WhichError {
+        #[from]
+        source: which::Error,
+    },
+
     #[cfg(any(feature = "s3", feature = "minio"))]
     #[error("Cloud Credentials Error: {source}")]
     CloudCredentialsError {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -105,6 +105,31 @@ pub enum StorageNewSubCommand {
         storage_dir: Option<String>,
     },
 
+    /// add a new rsync remote
+    #[clap()]
+    Rsync {
+        /// Name of the remote
+        ///
+        /// This must be unique among all remotes of the project
+        #[clap(long = "name", short = 'n')]
+        name: String,
+        /// Hostname for the connection in the form host.example.com  (without @, : or protocol)
+        #[clap(long)]
+        host: String,
+        /// Port number for the connection in the form 22.
+        /// Doesn't add port number to connection string if not given.
+        #[clap(long)]
+        port: Option<usize>,
+        /// User name for the connection, the part before @ in user@example.com (without @,
+        /// hostname).
+        /// User name isn't included in connection strings if not given.
+        #[clap(long)]
+        user: Option<String>,
+        /// Remote directory in the host to store the files.
+        #[clap(long)]
+        storage_dir: String,
+    },
+
     #[cfg(feature = "s3")]
     /// Add a new S3 remote
     #[clap()]
@@ -386,6 +411,22 @@ fn cmd_remote_new(
             bucket_name,
             endpoint,
             storage_prefix,
+        ),
+        StorageNewSubCommand::Rsync {
+            name,
+            host,
+            port,
+            user,
+            storage_dir,
+        } => storage::rsync::cmd_new_rsync(
+            input,
+            output_snd,
+            xvc_root,
+            name,
+            host,
+            port,
+            user,
+            storage_dir,
         ),
     }
 }

--- a/storage/src/storage/rsync.rs
+++ b/storage/src/storage/rsync.rs
@@ -1,0 +1,468 @@
+use std::{
+    cell::{Cell, RefCell},
+    collections::HashMap,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::anyhow;
+use crossbeam_channel::Sender;
+use regex::Regex;
+use relative_path::RelativePath;
+use serde::{Deserialize, Serialize};
+use subprocess::{CaptureData, Exec};
+use which::which;
+use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_ecs::R1NStore;
+use xvc_logging::{watch, XvcOutputLine};
+use xvc_walker::AbsolutePath;
+
+use crate::{Error, Result, XvcStorage, XvcStorageEvent, XvcStorageGuid, XvcStorageOperations};
+
+use super::{
+    XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent, XvcStoragePath,
+    XvcStorageReceiveEvent, XvcStorageSendEvent, XVC_STORAGE_GUID_FILENAME,
+};
+
+pub fn cmd_new_rsync(
+    input: std::io::StdinLock,
+    output_snd: Sender<XvcOutputLine>,
+    xvc_root: &XvcRoot,
+    name: String,
+    host: String,
+    port: Option<usize>,
+    user: Option<String>,
+    storage_dir: String,
+) -> Result<()> {
+    let storage = XvcRsyncStorage {
+        guid: XvcStorageGuid::new(),
+        name,
+        host,
+        port,
+        user,
+        storage_dir,
+    };
+
+    watch!(storage);
+
+    let init_event = storage.init(output_snd.clone(), xvc_root)?;
+
+    xvc_root.with_r1nstore_mut(|store: &mut R1NStore<XvcStorage, XvcStorageEvent>| {
+        let store_e = xvc_root.new_entity();
+        let event_e = xvc_root.new_entity();
+        store.insert(
+            store_e,
+            XvcStorage::Rsync(storage.clone()),
+            event_e,
+            XvcStorageEvent::Init(init_event.clone()),
+        );
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+pub struct XvcRsyncStorage {
+    pub guid: XvcStorageGuid,
+    pub name: String,
+    pub host: String,
+    pub port: Option<usize>,
+    pub user: Option<String>,
+    pub storage_dir: String,
+}
+
+impl XvcRsyncStorage {
+    fn ssh_url(&self) -> String {
+        match (self.port, &self.user) {
+            (None, None) => format!("{}", self.host),
+            (Some(port), None) => format!("{}:{port}", self.host),
+            (None, Some(user)) => format!("{user}@{}", self.host),
+            (Some(port), Some(user)) => format!("{user}@{}:{port}", self.host),
+        }
+    }
+
+    fn ssh_cmd(&self, ssh_executable: &AbsolutePath, cmd: &str) -> Result<CaptureData> {
+        let ssh_url = self.ssh_url();
+        watch!(ssh_url);
+        let cmd_res = Exec::cmd(ssh_executable.as_path())
+            .arg(ssh_url)
+            .arg(cmd)
+            .capture();
+
+        watch!(cmd_res);
+
+        match cmd_res {
+            Ok(res) => match res.exit_status {
+                subprocess::ExitStatus::Exited(0) => Ok(res),
+                subprocess::ExitStatus::Exited(_)
+                | subprocess::ExitStatus::Signaled(_)
+                | subprocess::ExitStatus::Other(_)
+                | subprocess::ExitStatus::Undetermined => Err(Error::ProcessError {
+                    stdout: res.stdout_str(),
+                    stderr: res.stderr_str(),
+                }),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn ssh_cache_path(&self, xvc_guid: &str, cache_path: &XvcCachePath) -> String {
+        let storage_dir = self.storage_dir.trim_end_matches('/');
+        format!("{storage_dir}/{xvc_guid}/{cache_path}")
+    }
+
+    fn ssh_cache_dir(&self, xvc_guid: &str, cache_path: &XvcCachePath) -> String {
+        let storage_dir = self.storage_dir.trim_end_matches('/');
+        let remote_dir = cache_path.directory();
+        format!("{storage_dir}/{xvc_guid}/{remote_dir}")
+    }
+
+    fn ssh_path(&self, path: &str) -> String {
+        let storage_dir = self.storage_dir.trim_end_matches('/');
+        format!("{storage_dir}/{path}")
+    }
+
+    fn rsync_path_url(&self, path: &str) -> String {
+        let storage_dir = self.storage_dir.trim_end_matches('/');
+        match (self.port, &self.user) {
+            (None, None) => format!("{}:{storage_dir}/{path}", self.host),
+            (Some(port), None) => format!("{}:{port}:{storage_dir}/{path}", self.host),
+            (None, Some(user)) => format!("{user}@{}:{storage_dir}/{path}", self.host),
+            (Some(port), Some(user)) => {
+                format!("{user}@{}:{port}:{storage_dir}/{path}", self.host,)
+            }
+        }
+    }
+
+    fn rsync_cache_url(&self, xvc_guid: &str, path: &XvcCachePath) -> String {
+        let storage_dir = self.storage_dir.trim_end_matches('/');
+        match (self.port, &self.user) {
+            (None, None) => format!("{}:{storage_dir}/{xvc_guid}/{path}", self.host),
+            (Some(port), None) => format!("{}:{port}:{storage_dir}/{xvc_guid}/{path}", self.host),
+            (None, Some(user)) => format!("{user}@{}:{storage_dir}/{xvc_guid}/{path}", self.host),
+            (Some(port), Some(user)) => format!(
+                "{user}@{}:{port}:{storage_dir}/{xvc_guid}/{path}",
+                self.host,
+            ),
+        }
+    }
+
+    fn rsync_copy_to_storage(
+        &self,
+        rsync_executable: &AbsolutePath,
+        local_path: &AbsolutePath,
+        remote_url: &str,
+    ) -> Result<CaptureData> {
+        let rsync_opts = "-av";
+
+        let cmd_res = Exec::cmd(rsync_executable.as_path())
+            .arg(rsync_opts)
+            .arg(local_path.to_string())
+            .arg(remote_url)
+            .capture();
+
+        match cmd_res {
+            Ok(res) => match res.exit_status {
+                subprocess::ExitStatus::Exited(0) => Ok(res),
+                subprocess::ExitStatus::Exited(_)
+                | subprocess::ExitStatus::Signaled(_)
+                | subprocess::ExitStatus::Other(_)
+                | subprocess::ExitStatus::Undetermined => Err(Error::ProcessError {
+                    stdout: res.stdout_str(),
+                    stderr: res.stderr_str(),
+                }),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn rsync_copy_from_storage(
+        &self,
+        rsync_executable: &AbsolutePath,
+        remote_url: &str,
+        local_path: &AbsolutePath,
+    ) -> Result<CaptureData> {
+        watch!(remote_url);
+        watch!(local_path);
+
+        let rsync_opts = "-av";
+
+        let cmd_res = Exec::cmd(rsync_executable.as_path())
+            .arg(rsync_opts)
+            .arg(remote_url)
+            .arg(local_path.to_string())
+            .capture();
+
+        watch!(cmd_res);
+
+        match cmd_res {
+            Ok(res) => match res.exit_status {
+                subprocess::ExitStatus::Exited(0) => Ok(res),
+                subprocess::ExitStatus::Exited(_)
+                | subprocess::ExitStatus::Signaled(_)
+                | subprocess::ExitStatus::Other(_)
+                | subprocess::ExitStatus::Undetermined => Err(Error::ProcessError {
+                    stdout: res.stdout_str(),
+                    stderr: res.stderr_str(),
+                }),
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    #[cfg(unix)]
+    fn ssh_executable() -> Result<AbsolutePath> {
+        Ok(AbsolutePath::from(which::which("ssh")?))
+    }
+
+    #[cfg(windows)]
+    fn ssh_executable() -> Result<AbsolutePath> {
+        Ok(AbsolutePath::from(which::which("ssh.exe")?))
+    }
+
+    #[cfg(unix)]
+    fn rsync_executable() -> Result<AbsolutePath> {
+        Ok(AbsolutePath::from(which::which("rsync")?))
+    }
+
+    #[cfg(windows)]
+    fn rsync_executable() -> Result<AbsolutePath> {
+        Ok(AbsolutePath::from(which::which("rsync.exe")?))
+    }
+
+    fn create_storage_dir(
+        &self,
+        ssh_executable: &AbsolutePath,
+        xvc_guid: &str,
+        cache_path: &XvcCachePath,
+    ) -> Result<CaptureData> {
+        let remote_dir = self.ssh_cache_dir(xvc_guid, cache_path);
+        self.ssh_cmd(&ssh_executable, &format!("mkdir -p '{}'", remote_dir))
+    }
+}
+
+impl XvcStorageOperations for XvcRsyncStorage {
+    /// Initialize the repository by copying guid file to remote storage directory.
+    fn init(
+        &self,
+        output: Sender<XvcOutputLine>,
+        xvc_root: &XvcRoot,
+    ) -> Result<super::XvcStorageInitEvent> {
+        // "--init",
+        // "ssh {URL} 'mkdir -p {STORAGE_DIR}' ; rsync -av {LOCAL_GUID_FILE_PATH} {URL}:{STORAGE_GUID_FILE_PATH}",
+        //
+
+        let ssh_executable = Self::ssh_executable()?;
+        let rsync_executable = Self::rsync_executable()?;
+
+        watch!(ssh_executable);
+        watch!(rsync_executable);
+
+        self.ssh_cmd(&ssh_executable, &format!("mkdir -p '{}'", self.storage_dir))?;
+
+        let local_guid_path = AbsolutePath::from(env::temp_dir().join(self.guid.to_string()));
+        fs::write(&local_guid_path, format!("{}", self.guid))?;
+        watch!(local_guid_path);
+
+        let remote_guid_path = self.rsync_path_url(XVC_STORAGE_GUID_FILENAME);
+
+        watch!(remote_guid_path);
+
+        let rsync_result =
+            self.rsync_copy_to_storage(&rsync_executable, &local_guid_path, &remote_guid_path)?;
+        watch!(rsync_result);
+
+        output.send(XvcOutputLine::Info(format!(
+            "Initialized:\n{}\n{}\n",
+            remote_guid_path,
+            rsync_result.stdout_str()
+        )))?;
+
+        fs::remove_file(&local_guid_path)?;
+
+        Ok(XvcStorageInitEvent {
+            guid: self.guid.clone(),
+        })
+    }
+
+    /// Lists all files in the remote directory that match to regex:
+    ///
+    /// {XVC_GUID}/[a-zA-Z][0-9]/[0-9A-Fa-f]{3}/[0-9A-Fa-f]{3}/[0-9A-Fa-f]{58}/0
+    fn list(
+        &self,
+        output: Sender<XvcOutputLine>,
+        xvc_root: &XvcRoot,
+    ) -> Result<XvcStorageListEvent> {
+        // "--list",
+        // "ssh {URL} 'ls -1R {STORAGE_DIR}'",
+        //
+        let ssh_executable = Self::ssh_executable()?;
+
+        let cmd_output = self.ssh_cmd(&ssh_executable, &format!("ls -1R {}", self.storage_dir))?;
+        let xvc_guid = xvc_root.config().guid().unwrap();
+        let re = Regex::new(&format!(
+            "{xvc_guid}/{cp}/{d3}/{d3}/{d58}/0\\..*$",
+            cp = r#"[a-zA-Z][0-9]"#,
+            d3 = r#"[0-9A-Fa-f]{3}"#,
+            d58 = r#"[0-9A-Fa-f]{58}"#
+        ))
+        .unwrap();
+
+        let paths = cmd_output
+            .stdout_str()
+            .lines()
+            .filter_map(|l| if re.is_match(l) { Some(l) } else { None })
+            .map(|l| XvcStoragePath::from(String::from(l)))
+            .collect();
+
+        Ok(XvcStorageListEvent {
+            guid: self.guid.clone(),
+            paths,
+        })
+    }
+
+    fn send(
+        &self,
+        output: Sender<XvcOutputLine>,
+        xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+        _force: bool,
+    ) -> Result<XvcStorageSendEvent> {
+        // "--upload",
+        // "ssh {URL} 'mkdir -p {STORAGE_DIR}{XVC_GUID}/{RELATIVE_CACHE_DIR}' ; rsync -av {ABSOLUTE_CACHE_PATH} {URL}:{STORAGE_DIR}{XVC_GUID}/{RELATIVE_CACHE_PATH}",
+        //
+        // TODO: We can make this parallel
+
+        let rsync_executable = Self::rsync_executable()?;
+        let ssh_executable = Self::ssh_executable()?;
+
+        let xvc_guid = xvc_root.config().guid().expect("Repo GUID");
+        let mut storage_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+        paths.iter().for_each(|cache_path| {
+            let local_path = cache_path.to_absolute_path(xvc_root);
+            let remote_url = self.rsync_cache_url(&xvc_guid, cache_path);
+            let remote_dir_res = self.create_storage_dir(&ssh_executable, &xvc_guid, cache_path);
+            // TODO: Handle possible error.
+            let cmd_output =
+                self.rsync_copy_to_storage(&rsync_executable, &local_path, &remote_url);
+
+            match cmd_output {
+                Ok(cmd_output) => {
+                    let stdout_str = cmd_output.stdout_str();
+                    let stderr_str = cmd_output.stderr_str();
+                    watch!(stdout_str);
+                    watch!(stderr_str);
+                    output.send(XvcOutputLine::Info(stdout_str)).unwrap();
+                    output.send(XvcOutputLine::Warn(stderr_str)).unwrap();
+                    let storage_path = XvcStoragePath::new(xvc_root, cache_path);
+                    storage_paths.push(storage_path);
+                }
+
+                Err(err) => {
+                    output.send(XvcOutputLine::Error(err.to_string())).unwrap();
+                }
+            }
+        });
+
+        Ok(XvcStorageSendEvent {
+            guid: self.guid.clone(),
+            paths: storage_paths,
+        })
+    }
+
+    fn receive(
+        &self,
+        output: Sender<XvcOutputLine>,
+        xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+        force: bool,
+    ) -> Result<XvcStorageReceiveEvent> {
+        // "--download",
+        // "mkdir -p {ABSOLUTE_CACHE_DIR} ; rsync -av {URL}:{STORAGE_DIR}{XVC_GUID}/{RELATIVE_CACHE_PATH} {ABSOLUTE_CACHE_PATH}",
+        //
+        let rsync_executable = Self::rsync_executable()?;
+
+        let xvc_guid = xvc_root.config().guid().expect("Repo GUID");
+        let mut storage_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+        paths.iter().for_each(|cache_path| {
+            let local_path = cache_path.to_absolute_path(xvc_root);
+            let remote_url = self.rsync_cache_url(&xvc_guid, cache_path);
+            let cache_dir = local_path.as_ref().parent().unwrap();
+            watch!(cache_dir);
+            if !cache_dir.exists() {
+                watch!(cache_dir);
+                fs::create_dir_all(&cache_dir);
+            }
+
+            watch!(remote_url);
+
+            let cmd_output =
+                self.rsync_copy_from_storage(&rsync_executable, &remote_url, &local_path);
+
+            match cmd_output {
+                Ok(cmd_output) => {
+                    let stdout_str = cmd_output.stdout_str();
+                    let stderr_str = cmd_output.stderr_str();
+                    watch!(stdout_str);
+                    watch!(stderr_str);
+                    output.send(XvcOutputLine::Info(stdout_str)).unwrap();
+                    output.send(XvcOutputLine::Warn(stderr_str)).unwrap();
+                    let storage_path = XvcStoragePath::new(xvc_root, cache_path);
+                    storage_paths.push(storage_path);
+                }
+
+                Err(err) => {
+                    output.send(XvcOutputLine::Error(err.to_string())).unwrap();
+                }
+            }
+        });
+
+        Ok(XvcStorageReceiveEvent {
+            guid: self.guid.clone(),
+            paths: storage_paths,
+        })
+    }
+
+    fn delete(
+        &self,
+        output: Sender<XvcOutputLine>,
+        xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+    ) -> Result<XvcStorageDeleteEvent> {
+        // "--delete",
+        // "ssh {URL} 'rm {STORAGE_DIR}{RELATIVE_CACHE_PATH}'",
+        //
+        let ssh_executable = Self::ssh_executable()?;
+
+        let xvc_guid = xvc_root.config().guid().expect("Repo GUID");
+        let mut storage_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+        paths.iter().for_each(|cache_path| {
+            let local_path = cache_path.to_absolute_path(xvc_root);
+            let remote_path = self.ssh_cache_path(xvc_guid.as_str(), cache_path);
+            let delete_cmd = format!("rm -f '{}'", remote_path);
+            let cmd_output = self.ssh_cmd(&ssh_executable, &delete_cmd);
+
+            match cmd_output {
+                Ok(cmd_output) => {
+                    let stdout_str = cmd_output.stdout_str();
+                    let stderr_str = cmd_output.stderr_str();
+                    watch!(stdout_str);
+                    watch!(stderr_str);
+                    output.send(XvcOutputLine::Info(stdout_str)).unwrap();
+                    output.send(XvcOutputLine::Warn(stderr_str)).unwrap();
+                    let storage_path = XvcStoragePath::new(xvc_root, cache_path);
+                    storage_paths.push(storage_path);
+                }
+
+                Err(err) => {
+                    output.send(XvcOutputLine::Error(err.to_string())).unwrap();
+                }
+            }
+        });
+        Ok(XvcStorageDeleteEvent {
+            guid: self.guid.clone(),
+            paths: storage_paths,
+        })
+    }
+}

--- a/workflow_tests/Cargo.toml
+++ b/workflow_tests/Cargo.toml
@@ -57,6 +57,7 @@ test-wasabi=["wasabi"]
 test-gcs =["gcs"]
 test-r2 = ["r2"]
 test-rsync = []
+test-generic-rsync = []
 
 
 


### PR DESCRIPTION
This PR adds `xvc storage new rsync` command to use remote storages via rsync. 

Closes #111 

