### PR TITLE
Update `xvc pipeline dag` to create more complex Graphviz diagrams

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
           brew install tree
 
       - name: Git config for automated Git tests
-        run: git config --global user.name 'Xvc Rabbit' && git config --global user.email 'rabbit@xvc.dev && git config --global init.defaultBranch main'
+        run: git config --global user.name 'Xvc Rabbit' && git config --global user.email 'rabbit@xvc.dev' && git config --global init.defaultBranch main
 
       - name: Write the private key file for one.emresult.com connection
         run: mkdir -p $HOME/.ssh/ && echo "${XVC_TEST_ONE_EMRESULT_COM_KEY}" > $HOME/.ssh/id_rsa ; chmod 600 ~/.ssh/id_rsa
@@ -99,6 +99,8 @@ jobs:
           args: ${{ matrix.test-args }}
         env:
           CARGO_INCREMENTAL: "0"
+          # To debug the output when commands fail
+          TRYCMD: "dump"
           RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
           RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off"
       - name: Coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
           brew install tree
 
       - name: Git config for automated Git tests
-        run: git config --global user.name 'Xvc Rabbit' && git config --global user.email 'rabbit@xvc.dev'
+        run: git config --global user.name 'Xvc Rabbit' && git config --global user.email 'rabbit@xvc.dev && git config --global init.defaultBranch main'
 
       - name: Write the private key file for one.emresult.com connection
         run: mkdir -p $HOME/.ssh/ && echo "${XVC_TEST_ONE_EMRESULT_COM_KEY}" > $HOME/.ssh/id_rsa ; chmod 600 ~/.ssh/id_rsa

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,18 +25,18 @@
         "./pipeline/Cargo.toml"
     ],
     "workbench.colorCustomizations": {
-        "titleBar.activeBackground": "#a6e559",
+        "titleBar.activeBackground": "#ed4d0e",
         "titleBar.activeForeground": "#000000",
-        "titleBar.inactiveBackground": "#a6e559",
+        "titleBar.inactiveBackground": "#ed4d0e",
         "titleBar.inactiveForeground": "#000000",
-        "titleBar.border": "#a6e559",
-        "activityBar.background": "#a6e559",
+        "titleBar.border": "#ed4d0e",
+        "activityBar.background": "#ed4d0e",
         "activityBar.foreground": "#000000",
-        "statusBar.background": "#a6e559",
+        "statusBar.background": "#ed4d0e",
         "statusBar.foreground": "#000000",
-        "statusBar.debuggingBackground": "#a6e559",
+        "statusBar.debuggingBackground": "#ed4d0e",
         "statusBar.debuggingForeground": "#000000",
-        "tab.activeBorder": "#a6e559",
+        "tab.activeBorder": "#ed4d0e",
         "iLoveWorkSpaceColors": true,
         "iLoveWorkSpaceRandom": true
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,21 @@
     "grammarly.config.suggestions.UnnecessaryEllipses": true,
     "rust-analyzer.linkedProjects": [
         "./pipeline/Cargo.toml"
-    ]
+    ],
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#a6e559",
+        "titleBar.activeForeground": "#000000",
+        "titleBar.inactiveBackground": "#a6e559",
+        "titleBar.inactiveForeground": "#000000",
+        "titleBar.border": "#a6e559",
+        "activityBar.background": "#a6e559",
+        "activityBar.foreground": "#000000",
+        "statusBar.background": "#a6e559",
+        "statusBar.foreground": "#000000",
+        "statusBar.debuggingBackground": "#a6e559",
+        "statusBar.debuggingForeground": "#000000",
+        "tab.activeBorder": "#a6e559",
+        "iLoveWorkSpaceColors": true,
+        "iLoveWorkSpaceRandom": true
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ tree, and subtasks are marked with indentation.
 - Added --min-size (-s) option to xvc-test-helper create-directory-tree
   - <https://github.com/iesahin/xvc/pull/229>
 - Updated `xvc pipeline dag` reference.
-  - 
+  - Step to step dependencies and other dependencies are shown differently
 
 
 ## 0.6.0 (2023-08-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ tree, and subtasks are marked with indentation.
 ## Unreleased
 
 - Added --min-size (-s) option to xvc-test-helper create-directory-tree
-  - <https://github.com/iesahin/xvc/pull/229>
-- Updated `xvc pipeline dag` reference.
-  - Step to step dependencies and other dependencies are shown differently
+  - PR: <https://github.com/iesahin/xvc/pull/229>
+- Updated `xvc pipeline dag` and reference docs.
+  - PR: <https://github.com/iesahin/xvc/pull/232>
+  - Dependency and outputs are shown with different shapes according to their types in Graphviz format
+  - Simplify DAG creation for both dot and mermaid formats
 
 
 ## 0.6.0 (2023-08-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ tree, and subtasks are marked with indentation.
 
 - Added --min-size (-s) option to xvc-test-helper create-directory-tree
   - <https://github.com/iesahin/xvc/pull/229>
+- Updated `xvc pipeline dag` reference.
+  - 
 
 
 ## 0.6.0 (2023-08-28)

--- a/book/src/how-to/git-branches.md
+++ b/book/src/how-to/git-branches.md
@@ -18,7 +18,7 @@ If `--from-ref` is not given, initial `git checkout` is not performed.
 Xvc operates in the current branch.
 This is the default behavior.
 
-```console
+```console,ignore
 $ git init --initial-branch=main
 ...
 $ xvc init
@@ -48,7 +48,7 @@ Total #: 1 Workspace Size:          19 Cached Size:          19
 
 If you return to `main` branch, you'll see the file is tracked by neither Git nor Xvc.
 
-```console
+```console,ignore
 $ git checkout main
 ...
 ```
@@ -67,7 +67,7 @@ $ git status -s
 Now, we'll add a step to the default pipeline to get an uppercase version of the data.
 We want this to work only in data
 
-```console
+```console,ignore
 $ xvc --from-ref data-file pipeline step new --step-name to-uppercase --command 'cat data.txt | tr a-z A-Z > uppercase.txt'
 Switched to branch 'data-file'
 
@@ -81,10 +81,10 @@ Note that `xvc pipeline step dependency` and `xvc pipeline step output` commands
 
 Now, we want to have this new version of data available only in `uppercase` branch.
 
-```console
+```console,ignore
 $ xvc --from-ref data-file --to-branch uppercase pipeline run
 Already on 'data-file'
-[OUT] [to-uppercase]  
+[OUT] [to-uppercase]
 Switched to a new branch 'uppercase'
 
 $ git branch
@@ -97,7 +97,7 @@ $ git branch
 You can use this for experimentation.
 Whenever you have a pipeline that you want to run and keep the results in another Git branch, you can use `--to-branch` for experimentation.
 
-```console
+```console,ignore
 $ xvcpr --from-ref data-file --to-branch another-uppercase
 $ git-branch
 * another-uppercase

--- a/book/src/how-to/git-branches.md
+++ b/book/src/how-to/git-branches.md
@@ -18,7 +18,7 @@ If `--from-ref` is not given, initial `git checkout` is not performed.
 Xvc operates in the current branch.
 This is the default behavior.
 
-```console,ignore
+```console
 $ git init --initial-branch=main
 ...
 $ xvc init
@@ -48,7 +48,7 @@ Total #: 1 Workspace Size:          19 Cached Size:          19
 
 If you return to `main` branch, you'll see the file is tracked by neither Git nor Xvc.
 
-```console,ignore
+```console
 $ git checkout main
 ...
 ```
@@ -67,7 +67,7 @@ $ git status -s
 Now, we'll add a step to the default pipeline to get an uppercase version of the data.
 We want this to work only in data
 
-```console,ignore
+```console
 $ xvc --from-ref data-file pipeline step new --step-name to-uppercase --command 'cat data.txt | tr a-z A-Z > uppercase.txt'
 Switched to branch 'data-file'
 
@@ -81,10 +81,10 @@ Note that `xvc pipeline step dependency` and `xvc pipeline step output` commands
 
 Now, we want to have this new version of data available only in `uppercase` branch.
 
-```console,ignore
+```console
 $ xvc --from-ref data-file --to-branch uppercase pipeline run
 Already on 'data-file'
-[OUT] [to-uppercase]
+[OUT] [to-uppercase]  
 Switched to a new branch 'uppercase'
 
 $ git branch
@@ -97,7 +97,7 @@ $ git branch
 You can use this for experimentation.
 Whenever you have a pipeline that you want to run and keep the results in another Git branch, you can use `--to-branch` for experimentation.
 
-```console,ignore
+```console
 $ xvcpr --from-ref data-file --to-branch another-uppercase
 $ git-branch
 * another-uppercase

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -11,22 +11,22 @@ Usage: xvc file copy [OPTIONS] <SOURCE> <DESTINATION>
 Arguments:
   <SOURCE>
           Source file, glob or directory within the workspace.
-          
+
           If the source ends with a slash, it's considered a directory and all files in that directory are copied.
-          
+
           If the number of source files is more than one, the destination must be a directory.
 
   <DESTINATION>
           Location we copy file(s) to within the workspace.
-          
+
           If the target ends with a slash, it's considered a directory and created if it doesn't exist.
-          
+
           If the number of source files is more than one, the destination must be a directory.
 
 Options:
       --recheck-method <RECHECK_METHOD>
           How the targets should be rechecked: One of copy, symlink, hardlink, reflink.
-          
+
           Note: Reflink uses copy if the underlying file system doesn't support it.
 
       --force
@@ -166,7 +166,7 @@ FH          19 [..] c85f3e81 c85f3e81 another-set/data2.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data.txt
 DX         160 [..]                   another-set
 FX         130 [..]          ac46bf74 .xvcignore
-FX         534 [..] .gitignore
+FX         [..] .gitignore
 Total #: 11 Workspace Size:        [..] Cached Size:          19
 
 

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -11,22 +11,22 @@ Usage: xvc file copy [OPTIONS] <SOURCE> <DESTINATION>
 Arguments:
   <SOURCE>
           Source file, glob or directory within the workspace.
-
+          
           If the source ends with a slash, it's considered a directory and all files in that directory are copied.
-
+          
           If the number of source files is more than one, the destination must be a directory.
 
   <DESTINATION>
           Location we copy file(s) to within the workspace.
-
+          
           If the target ends with a slash, it's considered a directory and created if it doesn't exist.
-
+          
           If the number of source files is more than one, the destination must be a directory.
 
 Options:
       --recheck-method <RECHECK_METHOD>
           How the targets should be rechecked: One of copy, symlink, hardlink, reflink.
-
+          
           Note: Reflink uses copy if the underlying file system doesn't support it.
 
       --force

--- a/book/src/ref/xvc-file-move.md
+++ b/book/src/ref/xvc-file-move.md
@@ -11,22 +11,22 @@ Usage: xvc file copy [OPTIONS] <SOURCE> <DESTINATION>
 Arguments:
   <SOURCE>
           Source file, glob or directory within the workspace.
-          
+
           If the source ends with a slash, it's considered a directory and all files in that directory are copied.
-          
+
           If the number of source files is more than one, the destination must be a directory.
 
   <DESTINATION>
           Location we copy file(s) to within the workspace.
-          
+
           If the target ends with a slash, it's considered a directory and created if it doesn't exist.
-          
+
           If the number of source files is more than one, the destination must be a directory.
 
 Options:
       --recheck-method <RECHECK_METHOD>
           How the targets should be rechecked: One of copy, symlink, hardlink, reflink.
-          
+
           Note: Reflink uses copy if the underlying file system doesn't support it.
 
       --force
@@ -127,8 +127,8 @@ XH                                 c85f3e81          data6.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data4.txt
 DX          96 [..]                   another-set
 FX         130 [..]          ac46bf74 .xvcignore
-FX         534 [..]          [..] .gitignore
-Total #: 5 Workspace Size:         779 Cached Size:          19
+FX         [..][..]          [..] .gitignore
+Total #: 5 Workspace Size:         774 Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-move.md
+++ b/book/src/ref/xvc-file-move.md
@@ -127,7 +127,7 @@ XH                                 c85f3e81          data6.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data4.txt
 DX          96 [..]                   another-set
 FX         130 [..]          ac46bf74 .xvcignore
-FX         [..][..]          [..] .gitignore
+FX         [..]              [..] .gitignore
 Total #: 5 Workspace Size:         774 Cached Size:          19
 
 

--- a/book/src/ref/xvc-file-move.md
+++ b/book/src/ref/xvc-file-move.md
@@ -11,22 +11,22 @@ Usage: xvc file copy [OPTIONS] <SOURCE> <DESTINATION>
 Arguments:
   <SOURCE>
           Source file, glob or directory within the workspace.
-
+          
           If the source ends with a slash, it's considered a directory and all files in that directory are copied.
-
+          
           If the number of source files is more than one, the destination must be a directory.
 
   <DESTINATION>
           Location we copy file(s) to within the workspace.
-
+          
           If the target ends with a slash, it's considered a directory and created if it doesn't exist.
-
+          
           If the number of source files is more than one, the destination must be a directory.
 
 Options:
       --recheck-method <RECHECK_METHOD>
           How the targets should be rechecked: One of copy, symlink, hardlink, reflink.
-
+          
           Note: Reflink uses copy if the underlying file system doesn't support it.
 
       --force
@@ -127,7 +127,7 @@ XH                                 c85f3e81          data6.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data4.txt
 DX          96 [..]                   another-set
 FX         130 [..]          ac46bf74 .xvcignore
-FX         [..]              [..] .gitignore
+FX         [..] .gitignore
 Total #: 5 Workspace Size:         774 Cached Size:          19
 
 

--- a/book/src/ref/xvc-file-remove.md
+++ b/book/src/ref/xvc-file-remove.md
@@ -282,7 +282,7 @@ $ xvc file list
 SS        [..] [..] 4a2e9d7c          data2.txt
 FC        1024 [..] 4a2e9d7c 4a2e9d7c data.txt
 FX         130 [..]          ac46bf74 .xvcignore
-FX         [..][..]          [..] .gitignore
+FX         [..] .gitignore
 Total #: 4 Workspace Size:        [..] Cached Size:        1024
 
 

--- a/book/src/ref/xvc-file-remove.md
+++ b/book/src/ref/xvc-file-remove.md
@@ -24,7 +24,7 @@ Options:
 
       --only-version <ONLY_VERSION>
           Remove only the specified version of the file
-
+          
           Versions are specified with the content hash 123-456-789abcd. Dashes are optional. Prefix must be unique. If the prefix is not unique, the command will fail.
 
       --force

--- a/book/src/ref/xvc-file-remove.md
+++ b/book/src/ref/xvc-file-remove.md
@@ -24,7 +24,7 @@ Options:
 
       --only-version <ONLY_VERSION>
           Remove only the specified version of the file
-          
+
           Versions are specified with the content hash 123-456-789abcd. Dashes are optional. Prefix must be unique. If the prefix is not unique, the command will fail.
 
       --force
@@ -60,7 +60,7 @@ $ xvc file list
 FC        [..] c85f3e81 c85f3e81 data.txt
 FX        [..]          ac46bf74 .xvcignore
 FX        [..] .gitignore
-Total #: 3 Workspace Size:         340 Cached Size:          19
+Total #: 3 Workspace Size:         [..] Cached Size:          19
 
 
 $ tree .xvc/b3/
@@ -120,7 +120,7 @@ $ xvc file list
 FC         [..] c85f3e81 c85f3e81 data.txt
 FX         [..]          ac46bf74 .xvcignore
 FX         [..]          [..] .gitignore
-Total #: 3 Workspace Size:         340 Cached Size:          19
+Total #: 3 Workspace Size:         [..] Cached Size:          19
 
 
 $ tree .xvc/b3/
@@ -159,7 +159,7 @@ $ xvc file list
 FC         [..] 6602cff6 6602cff6 data.txt
 FX         [..]          ac46bf74 .xvcignore
 FX         [..]          [..] .gitignore
-Total #: 3 Workspace Size:         340 Cached Size:          19
+Total #: 3 Workspace Size:         339 Cached Size:          19
 
 
 $ xvc file remove --from-cache --only-version c85-f3e data.txt
@@ -282,7 +282,7 @@ $ xvc file list
 SS        [..] [..] 4a2e9d7c          data2.txt
 FC        1024 [..] 4a2e9d7c 4a2e9d7c data.txt
 FX         130 [..]          ac46bf74 .xvcignore
-FX         276 [..]          [..] .gitignore
+FX         [..][..]          [..] .gitignore
 Total #: 4 Workspace Size:        [..] Cached Size:        1024
 
 

--- a/book/src/ref/xvc-file-untrack.md
+++ b/book/src/ref/xvc-file-untrack.md
@@ -36,7 +36,7 @@ $ xvc file track 'd*.txt'
 $ xvc file list
 FC          19 [..] c85f3e81 c85f3e81 data.txt
 FX         130 [..]          [..] .xvcignore
-FX         [..][..]          [..] .gitignore
+FX         [..] .gitignore
 Total #: 3 Workspace Size:         [..] Cached Size:          19
 
 

--- a/book/src/ref/xvc-file-untrack.md
+++ b/book/src/ref/xvc-file-untrack.md
@@ -19,7 +19,6 @@ Options:
 
 ```
 
-
 ## Examples
 
 This command removes a file from Xvc tracking and optionally deletes it from the local filesystem, cache, and the storages.
@@ -37,8 +36,8 @@ $ xvc file track 'd*.txt'
 $ xvc file list
 FC          19 [..] c85f3e81 c85f3e81 data.txt
 FX         130 [..]          [..] .xvcignore
-FX         191 [..]          [..] .gitignore
-Total #: 3 Workspace Size:         340 Cached Size:          19
+FX         [..][..]          [..] .gitignore
+Total #: 3 Workspace Size:         [..] Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -39,7 +39,14 @@ $ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
 
 $ xvc pipeline step new --step-name train --command "echo 'train'"
 
-$ xvc pipeline dependency new --step-name train --step preprocess
+$ xvc pipeline step dependency new --step-name train --step preprocess
+? 2
+error: unexpected argument 'new' found
+
+Usage: xvc pipeline step dependency [OPTIONS] --step-name <STEP_NAME>
+
+For more information, try '--help'.
+
 ```
 
 ```console

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -45,7 +45,7 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 
 ```console
 $ xvc pipeline dag
-digraph pipeline{n0[shape=box;label="train";];n1[shape=box;label="preprocess";];n0->n1;n1[shape=box;label="preprocess";];}
+digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=box;label="train";];n0[shape=box;label="preprocess";];n1->n0;}
 
 ```
 
@@ -64,6 +64,20 @@ You can use `--mermaid` option to get a [mermaid.js](https://mermaid.js.org) dia
 ```
 $ xvc pipeline dag --format=mermaid
 flowchart TD
-    n0["preprocess"]    n1["data/*"] --> n0    n2["train"]    n0["preprocess"] --> n2
+    n0["train"]
+    n1["preprocess"] --> n0
+    n1["preprocess"]
+    n2["data/*"] --> n1
 
+
+```
+
+The output can be used in [Mermaid Live Editor](https://mermaid.live) or any web page that support the format.
+
+```mermaid
+flowchart TD
+    n0["train"]
+    n1["preprocess"] --> n0
+    n1["preprocess"]
+    n2["data/*"] --> n1
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -25,16 +25,36 @@ As all other pipeline commands, this requires an Xvc repository.
 
 ```console
 $ git init
+Initialized empty Git repository in [CWD]/.git/
+
 $ xvc init
 ```
 
 All steps of the pipeline are shown as nodes in the graph.
 
 ```console
-$ xvc pipeline step new --name preprocess --command "echo 'preprocess'"
-$ xvc pipeline step new --name train --command "echo 'train'"
+$ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
+? 2
+error: unexpected argument '--name' found
+
+Usage: xvc pipeline step new [OPTIONS] --step-name <STEP_NAME> --command <COMMAND>
+
+For more information, try '--help'.
+
+$ xvc pipeline step new --step-name train --command "echo 'train'"
+? 2
+error: unexpected argument '--name' found
+
+Usage: xvc pipeline step new [OPTIONS] --step-name <STEP_NAME> --command <COMMAND>
+
+For more information, try '--help'.
+
 ```
 
 ```console
 $ xvc pipeline dag
+digraph {
+}
+
+
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -34,26 +34,22 @@ All steps of the pipeline are shown as nodes in the graph.
 
 ```console
 $ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
-? 2
-error: unexpected argument '--name' found
-
-Usage: xvc pipeline step new [OPTIONS] --step-name <STEP_NAME> --command <COMMAND>
-
-For more information, try '--help'.
 
 $ xvc pipeline step new --step-name train --command "echo 'train'"
-? 2
-error: unexpected argument '--name' found
-
-Usage: xvc pipeline step new [OPTIONS] --step-name <STEP_NAME> --command <COMMAND>
-
-For more information, try '--help'.
 
 ```
 
 ```console
 $ xvc pipeline dag
 digraph {
+    0 [ label = "step: START (always, )" ]
+    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    2 [ label = "step: END (never, )" ]
+    3 [ label = "step: train (by_dependencies, echo 'train')" ]
+    0 -> 1 [ label = "" ]
+    0 -> 3 [ label = "" ]
+    1 -> 2 [ label = "" ]
+    3 -> 2 [ label = "" ]
 }
 
 

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -15,3 +15,26 @@ Options:
   -h, --help             Print help
 
 ```
+
+You can visualize the pipeline you defined with [xvc pipeline](/ref/xvc-pipeline/) set of command with the `xvc pipeline
+dag` command. It will generate a dot or mermaid diagram for the pipeline.
+
+## Examples
+
+As all other pipeline commands, this requires an Xvc repository.
+
+```console
+$ git init
+$ xvc init
+```
+
+All steps of the pipeline are shown as nodes in the graph.
+
+```console
+$ xvc pipeline step new --name preprocess --command "echo 'preprocess'"
+$ xvc pipeline step new --name train --command "echo 'train'"
+```
+
+```console
+$ xvc pipeline dag
+```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -55,7 +55,7 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
-digraph pipeline{n0[shape=box;label="train";];n1[shape=box;label="preprocess";];n0->n1;n1[shape=box;label="preprocess";];n2[shape=folder;label="data/*";];n1->n2;}
+digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=folder;label="data/*";];n0->n1;n2[shape=box;label="train";];n0[shape=box;label="preprocess";];n2->n0;}
 
 ```
 

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -45,10 +45,19 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 
 ```console
 $ xvc pipeline dag
-? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
+digraph {
+    0 [ label = "step: START (always, )" ]
+    1 [ label = "step: START (always, )" ]
+    2 [ label = "step: train (by_dependencies, echo 'train')" ]
+    3 [ label = "step: train (by_dependencies, echo 'train')" ]
+    4 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    0 -> 0 [ label = "" ]
+    1 -> 1 [ label = "" ]
+    2 -> 2 [ label = "" ]
+    3 -> 3 [ label = "" ]
+    4 -> 4 [ label = "" ]
+}
+
 
 ```
 
@@ -58,9 +67,18 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
-? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
+digraph {
+    0 [ label = "step: START (always, )" ]
+    1 [ label = "step: START (always, )" ]
+    2 [ label = "step: train (by_dependencies, echo 'train')" ]
+    3 [ label = "step: train (by_dependencies, echo 'train')" ]
+    4 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    0 -> 0 [ label = "" ]
+    1 -> 1 [ label = "" ]
+    2 -> 2 [ label = "" ]
+    3 -> 3 [ label = "" ]
+    4 -> 4 [ label = "" ]
+}
+
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -47,15 +47,24 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 $ xvc pipeline dag
 digraph {
     0 [ label = "step: START (always, )" ]
-    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    1 [ label = "step: train (by_dependencies, echo 'train')" ]
     2 [ label = "step: END (never, )" ]
-    3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    0 -> 1 [ label = "" ]
-    0 -> 3 [ label = "" ]
-    1 -> 2 [ label = "" ]
-    3 -> 2 [ label = "" ]
-    3 -> 1 [ label = "" ]
+    3 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    0 -> 1 [ label = "step" ]
+    0 -> 3 [ label = "step" ]
+    1 -> 2 [ label = "step" ]
+    1 -> 3 [ label = "step" ]
+    3 -> 2 [ label = "step" ]
 }
 
+
+```
+
+When you add a dependency between two steps, the graph shows it as a node.
+
+```console
+$ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
+
+$ xvc pipeline dag
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -55,7 +55,7 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
-digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=folder;label="data/*";];n0->n1;n2[shape=box;label="train";];n0[shape=box;label="preprocess";];n2->n0;}
+digraph pipeline{n0[shape=box;label="train";];n1[shape=box;label="preprocess";];n0->n1;n1[shape=box;label="preprocess";];n2[shape=folder;label="data/*";];n1->n2;}
 
 ```
 
@@ -64,10 +64,10 @@ You can use `--mermaid` option to get a [mermaid.js](https://mermaid.js.org) dia
 ```
 $ xvc pipeline dag --format=mermaid
 flowchart TD
-    n0["train"]
-    n1["preprocess"] --> n0
-    n1["preprocess"]
-    n2["data/*"] --> n1
+    n0["preprocess"]
+    n1["data/*"] --> n0
+    n2["train"]
+    n0["preprocess"] --> n2
 
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -63,11 +63,7 @@ You can use `--mermaid` option to get a [mermaid.js](https://mermaid.js.org) dia
 
 ```
 $ xvc pipeline dag --format=mermaid
-? 2
-error: unexpected argument '--mermaid' found
-
-Usage: xvc pipeline dag [OPTIONS]
-
-For more information, try '--help'.
+flowchart TD
+    n0["preprocess"]    n1["data/*"] --> n0    n2["train"]    n0["preprocess"] --> n2
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -46,7 +46,7 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 ```console
 $ xvc pipeline dag
 ? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 
@@ -59,7 +59,7 @@ $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
 ? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -24,7 +24,7 @@ dag` command. It will generate a dot or mermaid diagram for the pipeline.
 As all other pipeline commands, this requires an Xvc repository.
 
 ```console
-$ git init
+$ git init --initial-branch=main
 Initialized empty Git repository in [CWD]/.git/
 
 $ xvc init

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -45,18 +45,10 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 
 ```console
 $ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
-    2 [ label = "step: END (never, )" ]
-    3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    0 -> 1 [ label = "" ]
-    0 -> 3 [ label = "" ]
-    1 -> 2 [ label = "" ]
-    3 -> 2 [ label = "" ]
-    3 -> 1 [ label = "" ]
-}
-
+? 101
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 
 ```
 
@@ -66,17 +58,9 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
-    2 [ label = "step: END (never, )" ]
-    3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    0 -> 1 [ label = "" ]
-    0 -> 3 [ label = "" ]
-    1 -> 2 [ label = "" ]
-    3 -> 2 [ label = "" ]
-    3 -> 1 [ label = "" ]
-}
-
+? 101
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -40,12 +40,6 @@ $ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
 $ xvc pipeline step new --step-name train --command "echo 'train'"
 
 $ xvc pipeline step dependency --step-name train --step preprocess
-? 2
-error: unexpected argument 'new' found
-
-Usage: xvc pipeline step dependency [OPTIONS] --step-name <STEP_NAME>
-
-For more information, try '--help'.
 
 ```
 
@@ -60,6 +54,7 @@ digraph {
     0 -> 3 [ label = "" ]
     1 -> 2 [ label = "" ]
     3 -> 2 [ label = "" ]
+    3 -> 1 [ label = "" ]
 }
 
 

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -45,7 +45,7 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 
 ```console
 $ xvc pipeline dag
-digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=box;label="train";];n0[shape=box;label="preprocess";];n1->n0;}
+digraph pipeline{n0[shape=box;label="train";];n1[shape=box;label="preprocess";];n0->n1;n1[shape=box;label="preprocess";];}
 
 ```
 
@@ -62,6 +62,12 @@ digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=folder;label="data/*
 You can use `--mermaid` option to get a [mermaid.js](https://mermaid.js.org) diagram.
 
 ```
-$ xvc pipeline dag --mermaid
+$ xvc pipeline dag --format=mermaid
+? 2
+error: unexpected argument '--mermaid' found
+
+Usage: xvc pipeline dag [OPTIONS]
+
+For more information, try '--help'.
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -47,14 +47,14 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 $ xvc pipeline dag
 digraph {
     0 [ label = "step: START (always, )" ]
-    1 [ label = "step: train (by_dependencies, echo 'train')" ]
+    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
     2 [ label = "step: END (never, )" ]
-    3 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
-    0 -> 1 [ label = "step" ]
-    0 -> 3 [ label = "step" ]
-    1 -> 2 [ label = "step" ]
-    1 -> 3 [ label = "step" ]
-    3 -> 2 [ label = "step" ]
+    3 [ label = "step: train (by_dependencies, echo 'train')" ]
+    0 -> 1 [ label = "" ]
+    0 -> 3 [ label = "" ]
+    1 -> 2 [ label = "" ]
+    3 -> 2 [ label = "" ]
+    3 -> 1 [ label = "" ]
 }
 
 
@@ -66,5 +66,17 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
+digraph {
+    0 [ label = "step: START (always, )" ]
+    1 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    2 [ label = "step: END (never, )" ]
+    3 [ label = "step: train (by_dependencies, echo 'train')" ]
+    0 -> 1 [ label = "" ]
+    0 -> 3 [ label = "" ]
+    1 -> 2 [ label = "" ]
+    3 -> 2 [ label = "" ]
+    3 -> 1 [ label = "" ]
+}
+
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -48,9 +48,9 @@ $ xvc pipeline dag
 digraph {
     0 [ label = "step: START (always, )" ]
     1 [ label = "step: START (always, )" ]
-    2 [ label = "step: train (by_dependencies, echo 'train')" ]
+    2 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
     3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    4 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    4 [ label = "step: train (by_dependencies, echo 'train')" ]
     0 -> 0 [ label = "" ]
     1 -> 1 [ label = "" ]
     2 -> 2 [ label = "" ]
@@ -70,9 +70,9 @@ $ xvc pipeline dag
 digraph {
     0 [ label = "step: START (always, )" ]
     1 [ label = "step: START (always, )" ]
-    2 [ label = "step: train (by_dependencies, echo 'train')" ]
+    2 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
     3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    4 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
+    4 [ label = "step: train (by_dependencies, echo 'train')" ]
     0 -> 0 [ label = "" ]
     1 -> 1 [ label = "" ]
     2 -> 2 [ label = "" ]

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -45,19 +45,7 @@ $ xvc pipeline step dependency --step-name train --step preprocess
 
 ```console
 $ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: START (always, )" ]
-    2 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
-    3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    4 [ label = "step: train (by_dependencies, echo 'train')" ]
-    0 -> 0 [ label = "" ]
-    1 -> 1 [ label = "" ]
-    2 -> 2 [ label = "" ]
-    3 -> 3 [ label = "" ]
-    4 -> 4 [ label = "" ]
-}
-
+digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=box;label="train";];n0[shape=box;label="preprocess";];n1->n0;}
 
 ```
 
@@ -67,18 +55,13 @@ When you add a dependency between two steps, the graph shows it as a node.
 $ xvc pipeline step dependency --step-name preprocess --glob 'data/*'
 
 $ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: START (always, )" ]
-    2 [ label = "step: preprocess (by_dependencies, echo 'preprocess')" ]
-    3 [ label = "step: train (by_dependencies, echo 'train')" ]
-    4 [ label = "step: train (by_dependencies, echo 'train')" ]
-    0 -> 0 [ label = "" ]
-    1 -> 1 [ label = "" ]
-    2 -> 2 [ label = "" ]
-    3 -> 3 [ label = "" ]
-    4 -> 4 [ label = "" ]
-}
+digraph pipeline{n0[shape=box;label="preprocess";];n1[shape=folder;label="data/*";];n0->n1;n2[shape=box;label="train";];n0[shape=box;label="preprocess";];n2->n0;}
 
+```
+
+You can use `--mermaid` option to get a [mermaid.js](https://mermaid.js.org) diagram.
+
+```
+$ xvc pipeline dag --mermaid
 
 ```

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -32,11 +32,14 @@ $ xvc init
 
 All steps of the pipeline are shown as nodes in the graph.
 
+We create a dependency between the two steps by using the `--dependencies` flag to make them run sequentially.
+
 ```console
 $ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
 
 $ xvc pipeline step new --step-name train --command "echo 'train'"
 
+$ xvc pipeline dependency new --step-name train --step preprocess
 ```
 
 ```console

--- a/book/src/ref/xvc-pipeline-dag.md
+++ b/book/src/ref/xvc-pipeline-dag.md
@@ -39,7 +39,7 @@ $ xvc pipeline step new --step-name preprocess --command "echo 'preprocess'"
 
 $ xvc pipeline step new --step-name train --command "echo 'train'"
 
-$ xvc pipeline step dependency new --step-name train --step preprocess
+$ xvc pipeline step dependency --step-name train --step preprocess
 ? 2
 error: unexpected argument 'new' found
 

--- a/book/src/ref/xvc-pipeline-run.md
+++ b/book/src/ref/xvc-pipeline-run.md
@@ -44,14 +44,10 @@ $ xvc pipeline step new --step-name hello --command "echo hello"
 
 ```console
 $ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: hello (by_dependencies, echo hello)" ]
-    2 [ label = "step: END (never, )" ]
-    0 -> 1 [ label = "" ]
-    1 -> 2 [ label = "" ]
-}
-
+? 101
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 
 ```
 

--- a/book/src/ref/xvc-pipeline-run.md
+++ b/book/src/ref/xvc-pipeline-run.md
@@ -43,24 +43,17 @@ $ xvc pipeline step new --step-name hello --command "echo hello"
 ```
 
 ```console
-$ xvc pipeline dag
-digraph {
-    0 [ label = "step: START (always, )" ]
-    1 [ label = "step: hello (by_dependencies, echo hello)" ]
-    0 -> 0 [ label = "" ]
-    1 -> 1 [ label = "" ]
-}
-
+$ xvc pipeline dag --format=mermaid
+digraph pipeline{n0[shape=box;label="hello";];}
 
 ```
-
 
 You can run the default pipeline without specifying its name.
 
 ```console
 $ xvc pipeline run
 [OUT] [hello] hello
- 
+
 
 ```
 
@@ -85,6 +78,6 @@ $ xvc pipeline --name my-pipeline step new --step-name my-hello --command "echo 
 ```console
 $ xvc pipeline run --name my-pipeline
 [OUT] [my-hello] hello from my-pipeline
- 
+
 
 ```

--- a/book/src/ref/xvc-pipeline-run.md
+++ b/book/src/ref/xvc-pipeline-run.md
@@ -44,10 +44,13 @@ $ xvc pipeline step new --step-name hello --command "echo hello"
 
 ```console
 $ xvc pipeline dag
-? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
+digraph {
+    0 [ label = "step: START (always, )" ]
+    1 [ label = "step: hello (by_dependencies, echo hello)" ]
+    0 -> 0 [ label = "" ]
+    1 -> 1 [ label = "" ]
+}
+
 
 ```
 

--- a/book/src/ref/xvc-pipeline-run.md
+++ b/book/src/ref/xvc-pipeline-run.md
@@ -44,7 +44,9 @@ $ xvc pipeline step new --step-name hello --command "echo hello"
 
 ```console
 $ xvc pipeline dag --format=mermaid
-digraph pipeline{n0[shape=box;label="hello";];}
+flowchart TD
+    n0["hello"]
+
 
 ```
 
@@ -53,7 +55,7 @@ You can run the default pipeline without specifying its name.
 ```console
 $ xvc pipeline run
 [OUT] [hello] hello
-
+ 
 
 ```
 
@@ -78,6 +80,6 @@ $ xvc pipeline --name my-pipeline step new --step-name my-hello --command "echo 
 ```console
 $ xvc pipeline run --name my-pipeline
 [OUT] [my-hello] hello from my-pipeline
-
+ 
 
 ```

--- a/book/src/ref/xvc-pipeline-run.md
+++ b/book/src/ref/xvc-pipeline-run.md
@@ -45,7 +45,7 @@ $ xvc pipeline step new --step-name hello --command "echo hello"
 ```console
 $ xvc pipeline dag
 ? 101
-thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:271:34
+thread '<unnamed>' panicked at 'no entry found for key', pipeline/src/pipeline/api/dag.rs:273:34
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any { .. }', lib/src/cli/mod.rs:403:37
 

--- a/book/src/ref/xvc-pipeline-step-dependency-generic.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-generic.md
@@ -40,9 +40,9 @@ You can mimic all kinds of pipeline behavior with this generic dependency.
 
 For example, if you want to run a command when directory contents change, you can depend on the output of `ls -lR`:
 
-```console,ignore
+```console
 $ xvc pipeline step new --step-name directory-contents --command "echo 'Files changed'"
-$ xvc pipeline step dependency --step-name directory-contents --generic 'ls -lR'
+$ xvc pipeline step dependency --step-name directory-contents --generic 'ls'
 
 $ xvc pipeline run
 [OUT] [directory-contents] Files changed

--- a/book/src/ref/xvc-pipeline-step-dependency-generic.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-generic.md
@@ -40,7 +40,7 @@ You can mimic all kinds of pipeline behavior with this generic dependency.
 
 For example, if you want to run a command when directory contents change, you can depend on the output of `ls -lR`:
 
-```console
+```console,ignore
 $ xvc pipeline step new --step-name directory-contents --command "echo 'Files changed'"
 $ xvc pipeline step dependency --step-name directory-contents --generic 'ls -lR'
 

--- a/book/src/ref/xvc-pipeline-step-dependency-glob-items.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-glob-items.md
@@ -1,4 +1,4 @@
-# Glob Items Dependency
+### Glob Items Dependency
 
 A step can depend on multiple files specified with globs. When any of the files change, or a new file is added or
 removed from the files specified by glob, the step is invalidated.

--- a/book/src/ref/xvc-pipeline-step-dependency-line-items.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-line-items.md
@@ -1,4 +1,4 @@
-# Line Item Dependencies
+### Line Item Dependencies
 
 You can make your steps to depend on lines of text files. The lines are defined by starting and ending indices.
 

--- a/book/src/ref/xvc-pipeline-step-dependency-lines.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-lines.md
@@ -1,4 +1,4 @@
-# Line Dependencies
+### Line Dependencies
 
 You can make your steps to depend on lines of text files. The lines are defined by starting and ending indices.
 

--- a/book/src/ref/xvc-pipeline-step-dependency-param.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-param.md
@@ -1,4 +1,4 @@
-# (Hyper-)Parameter Dependencies
+### (Hyper-)Parameter Dependencies
 
 You may be keeping pipeline-wide parameters in structured text files. You can specify such parameters found in JSON,
 TOML and YAML files as dependencies.

--- a/book/src/ref/xvc-pipeline-step-dependency-regex-items.md
+++ b/book/src/ref/xvc-pipeline-step-dependency-regex-items.md
@@ -1,4 +1,4 @@
-# Regex Item Dependencies
+### Regex Item Dependencies
 
 You can specify a regular expression matched against the lines from a file as a dependency. The step is invalidated when
 the matched results changed.

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -16,15 +16,15 @@ crate-type = ["rlib"]
 
 
 [dependencies]
-xvc-config = {version = "0.6.0",  path = "../config" }
+xvc-config = { version = "0.6.0", path = "../config" }
 xvc-core = { version = "0.6.0", path = "../core" }
 xvc-ecs = { version = "0.6.0", path = "../ecs" }
 xvc-logging = { version = "0.6.0", path = "../logging" }
-xvc-walker = {version = "0.6.0", path = "../walker"}
-xvc-file = {version = "0.6.0", path = "../file"}
+xvc-walker = { version = "0.6.0", path = "../walker" }
+xvc-file = { version = "0.6.0", path = "../file" }
 
 ## Cli and config
-clap = {version = "^4.4", features=["derive"]}
+clap = { version = "^4.4", features = ["derive"] }
 directories-next = "2.0"
 
 ## Hashing
@@ -72,6 +72,7 @@ comfy-table = "7.0.1"
 
 ## Graphs
 petgraph = "^0.6"
+tabbycat = "0.1.3"
 
 ## Misc
 subprocess = "^0.2"
@@ -89,5 +90,5 @@ itertools = "^0.11"
 derive_more = "^0.99"
 
 [dev-dependencies]
-xvc-test-helper = {path = "../test_helper/"}
+xvc-test-helper = { path = "../test_helper/" }
 test-case = "^3.2"

--- a/pipeline/src/error.rs
+++ b/pipeline/src/error.rs
@@ -199,6 +199,7 @@ pub enum Error {
     },
 }
 
+
 impl<T> From<crossbeam_channel::SendError<T>> for Error
 where
     T: Debug,

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -289,16 +289,11 @@ fn dependency_graph_stmts(
 ) -> Result<StmtList> {
     let mut stmts = StmtList::new();
 
-    let start_node = Identity::String("START".to_string());
-    let end_node = Identity::String("END".to_string());
 
     for (xe, step) in pipeline_steps.iter() {
         let step_identity = Identity::String(step.name.clone());
         let step_deps = all_deps.children_of(&xe)?;
         let step_outs = all_outs.children_of(&xe)?;
-
-        stmts = stmts.add_edge(Edge::head_node(start_node.clone(), None).arrow_to_node(step_identity.clone(), None));
-        stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(end_node.clone(), None));
 
         for (xe_dep, dep) in step_deps.iter() {
             let dep_identity = dep_identity(dep)?;

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -359,17 +359,17 @@ fn dependency_graph_stmts(
         let step_deps = all_deps.children_of(&xe)?;
         let step_outs = all_outs.children_of(&xe)?;
 
-        stmts = stmts.add_node(step_identity, None, Some(step_node_attributes(&step)));
+        stmts = stmts.add_node(step_identity.clone(), None, Some(step_node_attributes(&step)));
 
         for (xe_dep, dep) in step_deps.iter() {
             let dep_identity = dep_identity(dep)?;
-            stmts = stmts.add_node(dep_identity, None, Some(dep_node_attributes(&dep)));
+            stmts = stmts.add_node(dep_identity.clone(), None, Some(dep_node_attributes(&dep)));
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(dep_identity, None));
         }
 
         for (xe_dep, out) in step_outs.iter() {
             let out_identity = out_identity(out)?;
-            stmts = stmts.add_node(out_identity, None, Some(out_node_attributes(&out)));
+            stmts = stmts.add_node(out_identity.clone(), None, Some(out_node_attributes(&out)));
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity, None));
         }
     }

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -248,36 +248,36 @@ fn make_dot_graph(
     all_outs: &R1NStore<XvcStep, XvcOutput>,
 ) -> Result<String> {
     let graph = GraphBuilder::default()
-        .id(Identity::id("pipeline".to_string()?)
         .graph_type(tabbycat::GraphType::DiGraph)
         .strict(false)
+        .id(Identity::id("pipeline".to_string()))
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)
         .build().map_err(|e| anyhow::anyhow!("Failed to build graph. {e}"))?;
 
     Ok(graph.to_string())
 }
 
-fn dep_identity(dep: &XvcDependency) -> Identity {
+fn dep_identity(dep: &XvcDependency) -> Result<Identity> {
     match dep {
-        XvcDependency::Step(dep) => Identity::String(dep.name.clone()),
-        XvcDependency::Generic(dep) => Identity::String(dep.generic_command.clone()),
-        XvcDependency::File(dep) => Identity::String(dep.path.to_string()),
-        XvcDependency::GlobItems(dep) => Identity::String(dep.glob.to_string()),
-        XvcDependency::Glob(dep) => Identity::String(dep.glob.to_string()),
-        XvcDependency::RegexItems(dep) => Identity::String(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Regex(dep) => Identity::String(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Param(dep) => Identity::String(format!("{}::{}", dep.path.to_string(), dep.key.to_string())),
-        XvcDependency::LineItems(dep) => Identity::String(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::Lines(dep) => Identity::String(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::UrlDigest(dep) => Identity::String(dep.url.to_string()),
+        XvcDependency::Step(dep) => Identity::id(dep.name.clone()),
+        XvcDependency::Generic(dep) => Identity::id(dep.generic_command.clone()),
+        XvcDependency::File(dep) => Identity::id(dep.path.to_string()),
+        XvcDependency::GlobItems(dep) => Identity::id(dep.glob.to_string()),
+        XvcDependency::Glob(dep) => Identity::id(dep.glob.to_string()),
+        XvcDependency::RegexItems(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
+        XvcDependency::Regex(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
+        XvcDependency::Param(dep) => Identity::id(format!("{}::{}", dep.path.to_string(), dep.key.to_string())),
+        XvcDependency::LineItems(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
+        XvcDependency::Lines(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
+        XvcDependency::UrlDigest(dep) => Identity::id(dep.url.to_string()),
     }
 }
 
-fn out_identity(out: &XvcOutput) -> Identity {
+fn out_identity(out: &XvcOutput) -> Result<Identity> {
     match out {
-        XvcOutput::File { path } => Identity::String(path.to_string()),
-        XvcOutput::Metric { path, format } => Identity::String(path.to_string()),
-        XvcOutput::Image { path } => Identity::String(path.to_string()),
+        XvcOutput::File { path } => Identity::id(path.to_string()),
+        XvcOutput::Metric { path, format } => Identity::id(path.to_string()),
+        XvcOutput::Image { path } => Identity::id(path.to_string()),
     }
 }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -1,4 +1,5 @@
 use blake3::OUT_LEN;
+use clap::Id;
 use petgraph::algo::toposort;
 
 use petgraph::{dot::Dot, graph::NodeIndex, graphmap::DiGraphMap, Graph};
@@ -247,6 +248,7 @@ fn make_dot_graph(
     all_outs: &R1NStore<XvcStep, XvcOutput>,
 ) -> Result<String> {
     let graph = GraphBuilder::default()
+        .id(Identity::String("pipeline".to_string())
         .graph_type(tabbycat::GraphType::DiGraph)
         .strict(false)
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -257,16 +257,18 @@ fn make_dot_graph(
         })
     });
 
-    // for n in dependency_graph.nodes() {
-    //     let desc = &step_descs[&n];
-    //     let step_node = dot_graph.add_node(desc);
-    //     dot_nodes.map.insert(n, step_node);
-    // }
-    //
+    for n in dependency_graph.nodes() {
+        for (_, e_to, dep) in dependency_graph.edges(n) {
+            let desc = &step_descs[&n];
+            let step_node = dot_graph.add_node(desc);
+            dot_nodes.map.insert(n, step_node);
+        }
+    }
+
     for n in dependency_graph.nodes() {
         for (_, e_to, dep) in dependency_graph.edges(n) {
             let desc = &dep_descs[&e_to];
-            let step_node = dot_graph.add_node(desc);
+            let step_node = dot_nodes[&n];
             if matches!(dep, XvcDependency::Step { .. }) {
                 let other_step = dot_nodes[&e_to];
                 dot_graph.add_edge(step_node, other_step, "");

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -257,27 +257,32 @@ fn make_dot_graph(
     Ok(format!("{}", graph))
 }
 
+fn id_from_string(s: &str) -> Result<Identity> {
+    let hash_val = format!("node-{}", seahash::hash(s.as_bytes()));
+    Identity::id(hash_val).map_err(|e| e.into())
+}
+
 fn dep_identity(dep: &XvcDependency) -> Result<Identity> {
     match dep {
-        XvcDependency::Step(dep) => Identity::id(dep.name.clone()).map_err(|e| e.into()),
-        XvcDependency::Generic(dep) => Identity::id(dep.generic_command.clone()).map_err(|e| e.into()),
-        XvcDependency::File(dep) => Identity::id(dep.path.to_string()).map_err(|e| e.into()),
-        XvcDependency::GlobItems(dep) => Identity::id(dep.glob.to_string()).map_err(|e| e.into()),
-        XvcDependency::Glob(dep) => Identity::id(dep.glob.to_string()).map_err(|e| e.into()),
-        XvcDependency::RegexItems(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())).map_err(|e| e.into()),
-        XvcDependency::Regex(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())).map_err(|e| e.into()),
-        XvcDependency::Param(dep) => Identity::id(format!("{}::{}", dep.path.to_string(), dep.key.to_string())).map_err(|e| e.into()),
-        XvcDependency::LineItems(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())).map_err(|e| e.into()),
-        XvcDependency::Lines(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())).map_err(|e| e.into()),
-        XvcDependency::UrlDigest(dep) => Identity::id(dep.url.to_string()).map_err(|e| e.into()),
+        XvcDependency::Step(dep) => id_from_string(&dep.name),
+        XvcDependency::Generic(dep) => id_from_string(&dep.generic_command),
+        XvcDependency::File(dep) => id_from_string(&dep.path.to_string()),
+        XvcDependency::GlobItems(dep) => id_from_string(&dep.glob.to_string()),
+        XvcDependency::Glob(dep) => id_from_string(&dep.glob.to_string()),
+        XvcDependency::RegexItems(dep) => id_from_string(&format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
+        XvcDependency::Regex(dep) => id_from_string(&format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
+        XvcDependency::Param(dep) => id_from_string(&format!("{}::{}", dep.path.to_string(), dep.key.to_string())),
+        XvcDependency::LineItems(dep) => id_from_string(&format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
+        XvcDependency::Lines(dep) => id_from_string(&format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
+        XvcDependency::UrlDigest(dep) => id_from_string(&dep.url.to_string()),
     }
 }
 
 fn out_identity(out: &XvcOutput) -> Result<Identity> {
     match out {
-        XvcOutput::File { path } => Identity::id(path.to_string()).map_err(|e| e.into()),
-        XvcOutput::Metric { path, format } => Identity::id(path.to_string()).map_err(|e| e.into()),
-        XvcOutput::Image { path } => Identity::id(path.to_string()).map_err(|e| e.into()),
+        XvcOutput::File { path } => id_from_string(&path.to_string()),
+        XvcOutput::Metric { path,  .. } => id_from_string(&path.to_string()),
+        XvcOutput::Image { path } => id_from_string(&path.to_string()),
     }
 }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -258,21 +258,25 @@ fn make_dot_graph(
         })
     });
 
-    for (e_from, e_to, dep) in dependency_graph.edges(n) {
-        let desc = &step_descs[&e_from];
-        let step_node = dot_graph.add_node(desc);
-        dot_nodes.insert((e_from, e_to), step_node);
+    for n in dependency_graph.nodes() {
+        for (e_from, e_to, dep) in dependency_graph.edges(n) {
+            let desc = &step_descs[&e_from];
+            let step_node = dot_graph.add_node(desc);
+            dot_nodes.insert((e_from, e_to), step_node);
+        }
     }
 
-    for (e_from, e_to, dep) in dependency_graph.edges(n) {
-        let step_node = dot_nodes[&(e_from, e_to)];
-        let desc = &dep_descs[&e_to];
-        if matches!(dep, XvcDependency::Step { .. }) {
-            let other_step = dot_nodes[&(e_from, e_to)];
-            dot_graph.add_edge(step_node, other_step, "");
-        } else {
-            let dep_node = dot_graph.add_node(desc);
-            dot_graph.add_edge(step_node, dep_node, "");
+    for n in dependency_graph.nodes() {
+        for (e_from, e_to, dep) in dependency_graph.edges(n) {
+            let step_node = dot_nodes[&(e_from, e_to)];
+            let desc = &dep_descs[&e_to];
+            if matches!(dep, XvcDependency::Step { .. }) {
+                let other_step = dot_nodes[&(e_from, e_to)];
+                dot_graph.add_edge(step_node, other_step, "");
+            } else {
+                let dep_node = dot_graph.add_node(desc);
+                dot_graph.add_edge(step_node, dep_node, "");
+            }
         }
     }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -254,7 +254,7 @@ fn make_dot_graph(
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)
         .build().map_err(|e| anyhow::anyhow!("Failed to build graph. {e}"))?;
 
-    Ok(format!("{:#?}", graph.to_string()))
+    Ok(format!("{}", graph))
 }
 
 fn dep_identity(dep: &XvcDependency) -> Result<Identity> {

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -369,7 +369,7 @@ fn dependency_graph_stmts(
 
         for (xe_dep, out) in step_outs.iter() {
             let out_identity = out_identity(out)?;
-            stmts = stmts.add_node(out_identity, None, Some(out_node_attributes(&dep)));
+            stmts = stmts.add_node(out_identity, None, Some(out_node_attributes(&out)));
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity, None));
         }
     }

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -257,8 +257,8 @@ fn make_dot_graph(
 
 fn dep_identity(dep: &XvcDependency) -> Identity {
     match dep {
-        XvcDependency::Step(dep) => Identity::String(dep.name),
-        XvcDependency::Generic(dep) => Identity::String(dep.generic_command),
+        XvcDependency::Step(dep) => Identity::String(dep.name.clone()),
+        XvcDependency::Generic(dep) => Identity::String(dep.generic_command.clone()),
         XvcDependency::File(dep) => Identity::String(dep.path.to_string()),
         XvcDependency::GlobItems(dep) => Identity::String(dep.glob.to_string()),
         XvcDependency::Glob(dep) => Identity::String(dep.glob.to_string()),
@@ -295,20 +295,20 @@ fn dependency_graph_stmts(
         let step_deps = all_deps.children_of(&xe)?;
         let step_outs = all_outs.children_of(&xe)?;
 
-        stmts.add_edge(Edge::head_node(start_node, None).arrow_to_node(step_identity, None));
-        stmts.add_edge(Edge::head_node(step_identity, None).arrow_to_node(end_node, None));
+        stmts = stmts.add_edge(Edge::head_node(start_node.clone(), None).arrow_to_node(step_identity.clone(), None));
+        stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(end_node.clone(), None));
 
         for (xe_dep, dep) in step_deps.iter() {
             let dep_identity = dep_identity(dep);
-            stmts.add_edge(Edge::head_node(step_identity, None).arrow_to_node(dep_identity, None));
+            stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(dep_identity, None));
         }
 
         for (xe_dep, out) in step_outs.iter() {
-            stmts.add_edge(Edge::head_node(step_identity, None).arrow_to_node(out_identity(out), None));
+            stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity(out), None));
         }
     }
 
-    stmts
+    Ok(stmts)
 }
 
 /// Create a mermaid diagram from the given Graph.

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -270,10 +270,10 @@ fn make_dot_graph(
             let desc = &dep_descs[&e_to];
             if matches!(dep, XvcDependency::Step { .. }) {
                 let other_step = output_nodes[&e_to];
-                output_graph.add_edge(step_node, other_step, "step");
+                output_graph.add_edge(step_node, other_step, "");
             } else {
                 let dep_node = output_graph.add_node(desc);
-                output_graph.add_edge(step_node, dep_node, "dep");
+                output_graph.add_edge(step_node, dep_node, "");
             }
         }
     }

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -250,7 +250,7 @@ fn make_dot_graph(
     let graph = GraphBuilder::default()
         .graph_type(tabbycat::GraphType::DiGraph)
         .strict(false)
-        .id(Identity::id("pipeline".to_string()))
+        .id(Identity::id("pipeline".to_string())?)
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)
         .build().map_err(|e| anyhow::anyhow!("Failed to build graph. {e}"))?;
 
@@ -259,25 +259,25 @@ fn make_dot_graph(
 
 fn dep_identity(dep: &XvcDependency) -> Result<Identity> {
     match dep {
-        XvcDependency::Step(dep) => Identity::id(dep.name.clone()),
-        XvcDependency::Generic(dep) => Identity::id(dep.generic_command.clone()),
-        XvcDependency::File(dep) => Identity::id(dep.path.to_string()),
-        XvcDependency::GlobItems(dep) => Identity::id(dep.glob.to_string()),
-        XvcDependency::Glob(dep) => Identity::id(dep.glob.to_string()),
-        XvcDependency::RegexItems(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Regex(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Param(dep) => Identity::id(format!("{}::{}", dep.path.to_string(), dep.key.to_string())),
-        XvcDependency::LineItems(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::Lines(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::UrlDigest(dep) => Identity::id(dep.url.to_string()),
+        XvcDependency::Step(dep) => Identity::id(dep.name.clone()).map_err(|e| e.into()),
+        XvcDependency::Generic(dep) => Identity::id(dep.generic_command.clone()).map_err(|e| e.into()),
+        XvcDependency::File(dep) => Identity::id(dep.path.to_string()).map_err(|e| e.into()),
+        XvcDependency::GlobItems(dep) => Identity::id(dep.glob.to_string()).map_err(|e| e.into()),
+        XvcDependency::Glob(dep) => Identity::id(dep.glob.to_string()).map_err(|e| e.into()),
+        XvcDependency::RegexItems(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())).map_err(|e| e.into()),
+        XvcDependency::Regex(dep) => Identity::id(format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())).map_err(|e| e.into()),
+        XvcDependency::Param(dep) => Identity::id(format!("{}::{}", dep.path.to_string(), dep.key.to_string())).map_err(|e| e.into()),
+        XvcDependency::LineItems(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())).map_err(|e| e.into()),
+        XvcDependency::Lines(dep) => Identity::id(format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())).map_err(|e| e.into()),
+        XvcDependency::UrlDigest(dep) => Identity::id(dep.url.to_string()).map_err(|e| e.into()),
     }
 }
 
 fn out_identity(out: &XvcOutput) -> Result<Identity> {
     match out {
-        XvcOutput::File { path } => Identity::id(path.to_string()),
-        XvcOutput::Metric { path, format } => Identity::id(path.to_string()),
-        XvcOutput::Image { path } => Identity::id(path.to_string()),
+        XvcOutput::File { path } => Identity::id(path.to_string()).map_err(|e| e.into()),
+        XvcOutput::Metric { path, format } => Identity::id(path.to_string()).map_err(|e| e.into()),
+        XvcOutput::Image { path } => Identity::id(path.to_string()).map_err(|e| e.into()),
     }
 }
 
@@ -301,12 +301,12 @@ fn dependency_graph_stmts(
         stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(end_node.clone(), None));
 
         for (xe_dep, dep) in step_deps.iter() {
-            let dep_identity = dep_identity(dep);
+            let dep_identity = dep_identity(dep)?;
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(dep_identity, None));
         }
 
         for (xe_dep, out) in step_outs.iter() {
-            stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity(out), None));
+            stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity(out)?, None));
         }
     }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -308,17 +308,17 @@ fn dep_node_attributes(dep: &XvcDependency) -> AttrList {
     };
 
     let dep_label = match dep {
-        XvcDependency::Step(dep) => (&dep.name),
-        XvcDependency::Generic(dep) => (&dep.generic_command),
-        XvcDependency::File(dep) => (&dep.path.to_string()),
-        XvcDependency::GlobItems(dep) => (&dep.glob.to_string()),
-        XvcDependency::Glob(dep) => (&dep.glob.to_string()),
-        XvcDependency::RegexItems(dep) => (&format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Regex(dep) => (&format!("{}:/{}", dep.path.to_string(), dep.regex.to_string())),
-        XvcDependency::Param(dep) => (&format!("{}::{}", dep.path.to_string(), dep.key.to_string())),
-        XvcDependency::LineItems(dep) => (&format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::Lines(dep) => (&format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string())),
-        XvcDependency::UrlDigest(dep) => (&dep.url.to_string()),
+        XvcDependency::Step(dep) => dep.name.clone(),
+        XvcDependency::Generic(dep) => dep.generic_command.clone(),
+        XvcDependency::File(dep) => dep.path.to_string(),
+        XvcDependency::GlobItems(dep) => dep.glob.to_string(),
+        XvcDependency::Glob(dep) => dep.glob.to_string(),
+        XvcDependency::RegexItems(dep) => format!("{}:/{}", dep.path.to_string(), dep.regex.to_string()),
+        XvcDependency::Regex(dep) => format!("{}:/{}", dep.path.to_string(), dep.regex.to_string()),
+        XvcDependency::Param(dep) => format!("{}::{}", dep.path.to_string(), dep.key.to_string()),
+        XvcDependency::LineItems(dep) => format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string()),
+        XvcDependency::Lines(dep) => format!("{}::{}-{}", dep.path.to_string(),dep.begin.to_string(), dep.end.to_string()),
+        XvcDependency::UrlDigest(dep) => dep.url.to_string(),
     };
 
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -362,20 +362,20 @@ fn make_mermaid_graph(
 
         let step_label = s.name.clone();
         let step_id = short_id(id_from_string(&step_label)?)?;
-        res_string.push_str(&format!("    {}[\"{}\"]", step_id, step_label));
+        res_string.push_str(&format!("    {}[\"{}\"]\n", step_id, step_label));
 
         for (_, dep) in deps.iter() {
             let dep_label = dep_label(dep);
             let dep_id = short_id(id_from_string(&dep_label)?)?;
             // TODO: Specialize the shape according to dependency type
-            res_string.push_str(&format!("    {}[\"{}\"] --> {}", dep_id, dep_label, step_id));
+            res_string.push_str(&format!("    {}[\"{}\"] --> {}\n", dep_id, dep_label, step_id));
         }
 
         for (_, out) in outs.iter() {
             let out_label = out_label(out);
             let out_id = short_id(id_from_string(&out_label)?)?;
             // TODO: Add commands that produce these outputs
-            res_string.push_str(&format!("    {}[\"{}\"] --> {}", out_id, out_label, step_id));
+            res_string.push_str(&format!("    {}[\"{}\"] --> {}\n", out_id, out_label, step_id));
         }
     }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -349,7 +349,7 @@ fn dependency_graph_stmts(
 
     let  mut id_map = HashMap::<String, Identity>::new();
 
-    let short_id = |id: Identity| -> Result<Identity> {
+    let mut short_id = |id: Identity| -> Result<Identity> {
         let str_key = id.to_string();
         if !id_map.contains_key(&str_key) {
             id_map.insert(str_key.clone(), Identity::id(format!("n{}", id_map.len()))?);
@@ -358,20 +358,20 @@ fn dependency_graph_stmts(
     };
 
     for (xe, step) in pipeline_steps.iter() {
-        let step_identity = id_from_string(&step.name)?;
+        let step_identity = short_id(id_from_string(&step.name)?)?;
         let step_deps = all_deps.children_of(&xe)?;
         let step_outs = all_outs.children_of(&xe)?;
 
         stmts = stmts.add_node(step_identity.clone(), None, Some(step_node_attributes(&step)));
 
         for (xe_dep, dep) in step_deps.iter() {
-            let dep_identity = dep_identity(dep)?;
+            let dep_identity = short_id(dep_identity(dep)?)?;
             stmts = stmts.add_node(dep_identity.clone(), None, Some(dep_node_attributes(&dep)));
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(dep_identity, None));
         }
 
         for (xe_dep, out) in step_outs.iter() {
-            let out_identity = out_identity(out)?;
+            let out_identity = short_id(out_identity(out)?)?;
             stmts = stmts.add_node(out_identity.clone(), None, Some(out_node_attributes(&out)));
             stmts = stmts.add_edge(Edge::head_node(step_identity.clone(), None).arrow_to_node(out_identity, None));
         }

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -254,7 +254,7 @@ fn make_dot_graph(
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)
         .build().map_err(|e| anyhow::anyhow!("Failed to build graph. {e}"))?;
 
-    Ok(format!("{:#?}", graph))
+    Ok(format!("{:#?}", graph.to_string()))
 }
 
 fn dep_identity(dep: &XvcDependency) -> Result<Identity> {

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -1,4 +1,3 @@
-use cached::proc_macro::cached;
 use petgraph::algo::toposort;
 
 use petgraph::graphmap::DiGraphMap;
@@ -283,7 +282,7 @@ fn out_identity(out: &XvcOutput) -> Result<Identity> {
 }
 
 fn step_node_attributes(step: &XvcStep) -> AttrList {
-    AttrList::new().add_pair(shape(Shape::Box))
+    AttrList::new().add_pair(shape(Shape::Box)).add_pair(label(step.name.clone()))
 }
 
 fn dep_node_attributes(dep: &XvcDependency) -> AttrList {

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -258,7 +258,7 @@ fn make_dot_graph(
 }
 
 fn id_from_string(s: &str) -> Result<Identity> {
-    let hash_val = format!("node-{}", seahash::hash(s.as_bytes()));
+    let hash_val = format!("i{}", seahash::hash(s.as_bytes()));
     Identity::id(hash_val).map_err(|e| e.into())
 }
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -248,7 +248,7 @@ fn make_dot_graph(
     all_outs: &R1NStore<XvcStep, XvcOutput>,
 ) -> Result<String> {
     let graph = GraphBuilder::default()
-        .id(Identity::String("pipeline".to_string())
+        .id(Identity::id("pipeline".to_string()?)
         .graph_type(tabbycat::GraphType::DiGraph)
         .strict(false)
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -19,7 +19,6 @@ use crate::{
     XvcDependency, XvcOutput, XvcPipeline, XvcPipelineRunDir, XvcStep, XvcStepCommand,
 };
 
-
 #[derive(Debug, Clone, Eq, PartialEq, EnumString, Display, IntoStaticStr)]
 #[strum(serialize_all = "lowercase")]
 pub enum XvcPipelineDagFormat {
@@ -271,10 +270,10 @@ fn make_dot_graph(
             let desc = &dep_descs[&e_to];
             if matches!(dep, XvcDependency::Step { .. }) {
                 let other_step = output_nodes[&e_to];
-                output_graph.add_edge(step_node, other_step, "");
+                output_graph.add_edge(step_node, other_step, "step");
             } else {
                 let dep_node = output_graph.add_node(desc);
-                output_graph.add_edge(step_node, dep_node, "");
+                output_graph.add_edge(step_node, dep_node, "dep");
             }
         }
     }

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -254,7 +254,7 @@ fn make_dot_graph(
         .stmts(dependency_graph_stmts(pipeline_steps, all_deps, all_outs)?)
         .build().map_err(|e| anyhow::anyhow!("Failed to build graph. {e}"))?;
 
-    Ok(graph.to_string())
+    Ok(format!("{:#?}", graph))
 }
 
 fn dep_identity(dep: &XvcDependency) -> Result<Identity> {

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -250,11 +250,11 @@ fn make_dot_graph(
         dependency_graph.node_count() + dependency_graph.edge_count(),
         dependency_graph.edge_count() * dependency_graph.node_count(),
     );
-    let mut dep_descs = HStore::<String>::new();
+    let mut dep_descs = HashMap::<(XvcEntity, XvcEntity), String>::new();
     dependency_graph.nodes().for_each(|e_from| {
         dependency_graph.edges(e_from).for_each(|(_, e_to, dep)| {
             let dep = dep_desc(pipeline_steps, step_descs, dep);
-            dep_descs.insert(e_to, dep);
+            dep_descs.insert((e_from, e_to), dep);
         })
     });
 
@@ -269,7 +269,7 @@ fn make_dot_graph(
     for n in dependency_graph.nodes() {
         for (e_from, e_to, dep) in dependency_graph.edges(n) {
             let step_node = dot_nodes[&(e_from, e_to)];
-            let desc = &dep_descs[&e_to];
+            let desc = &dep_descs[&(e_from, e_to)];
             if matches!(dep, XvcDependency::Step { .. }) {
                 let other_step = dot_nodes[&(e_from, e_to)];
                 dot_graph.add_edge(step_node, other_step, "");

--- a/pipeline/src/pipeline/deps/digest.rs
+++ b/pipeline/src/pipeline/deps/digest.rs
@@ -15,7 +15,7 @@ use xvc_core::util::file::{
     filter_paths_by_directory, glob_paths, XvcPathMetadataMap,
 };
 use xvc_core::{
-    AttributeDigest, ContentDigest, HashAlgorithm, PathCollectionDigest,
+    ContentDigest, HashAlgorithm, PathCollectionDigest,
     XvcDigest, XvcMetadataDigest, XvcPath, XvcRoot,
 };
 

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -1,3 +1,4 @@
+//! Cloud storage implementations for xvc.
 #[cfg(feature = "digital-ocean")]
 pub mod digital_ocean;
 pub mod event;

--- a/workflow_tests/tests/z_test_docs.rs
+++ b/workflow_tests/tests/z_test_docs.rs
@@ -144,6 +144,7 @@ fn z_doc_tests() -> Result<()> {
         .register_bin("perl", which::which("perl"))
         .register_bin("tree", which::which("tree"))
         .register_bin("zsh", which::which("zsh"))
+        .register_bin("dot", which::which("dot"))
         .case("docs/*/*.md")
         .timeout(Duration::from_secs(10))
         // We skip this for the time being.


### PR DESCRIPTION
This updates `xvc pipeline dag`  dot output to create diagrams that show different types of dependencies with different node shapes. 

It also simplifies how diagrams are created. 