### PR TITLE
v0.6.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,12 @@ jobs:
             command: build
             args: "--release --features=bundled-openssl"
 
-          - os-name: NetBSD-x86_64
-            runs-on: ubuntu-22.04
-            target: x86_64-unknown-netbsd
-            command: build
-            args: "--release --features=bundled-openssl"
+          # gh -R iesahin/xvc run view 12525597866 --log-failed
+          # - os-name: NetBSD-x86_64
+          #   runs-on: ubuntu-22.04
+          #   target: x86_64-unknown-netbsd
+          #   command: build
+          #   args: "--release --features=bundled-openssl"
 
           - os-name: Windows-x86_64
             runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,12 +42,6 @@ jobs:
           #   command: build
           #   args: "--release --features=bundled-openssl"
 
-          - os-name: Linux-aarch64
-            runs-on: ubuntu-22.04
-            target: aarch64-unknown-linux-musl
-            command: build
-            args: "--release --features=bundled-openssl,bundled-sqlite"
-
           # gh -R iesahin/xvc run view 12525734325 --log-failed
           # - os-name: Linux-Android
           #   runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - os-name: FreeBSD-x86_64
-            runs-on: ubuntu-20.04
-            target: x86_64-unknown-freebsd
-            skip_tests: true
+          # - os-name: FreeBSD-x86_64
+          #   runs-on: ubuntu-20.04
+          #   target: x86_64-unknown-freebsd
+          #   skip_tests: true
 
           - os-name: Linux-x86_64
             runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   # schedule:
   #   - cron: "17 17 * * *"
-  pull_request:
+  # pull_request:
   #  types: [labeled, review_requested]
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "17 17 * * *"
+  pull_request:
+  #  types: [labeled, review_requested]
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    name: Release - ${{ matrix.platform.os-name }}
+    strategy:
+      matrix:
+        platform:
+          - os-name: FreeBSD-x86_64
+            runs-on: ubuntu-20.04
+            target: x86_64-unknown-freebsd
+            skip_tests: true
+
+          - os-name: Linux-x86_64
+            runs-on: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+
+          - os-name: Linux-aarch64
+            runs-on: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+
+          - os-name: Linux-riscv64
+            runs-on: ubuntu-20.04
+            target: riscv64gc-unknown-linux-gnu
+
+          - os-name: Windows-x86_64
+            runs-on: windows-latest
+            target: x86_64-pc-windows-msvc
+
+          - os-name: macOS-x86_64
+            runs-on: macOS-latest
+            target: x86_64-apple-darwin
+
+          # more targets here ...
+
+    runs-on: ${{ matrix.platform.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: ${{ matrix.platform.command }}
+          target: ${{ matrix.platform.target }}
+          args: "--locked --release"
+          strip: true
+      - name: Publish artifacts and release
+        uses: houseabsolute/actions-rust-release@v0
+        with:
+          executable-name: ubi
+          target: ${{ matrix.platform.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             command: build
             args: "--release --features=bundled-openssl"
 
+            # FIXME: We need to install libsqlite in some of these targets but this is for later.
           - os-name: Linux-aarch64
             runs-on: ubuntu-20.04
             target: aarch64-unknown-linux-musl
@@ -47,11 +48,12 @@ jobs:
             command: build
             args: "--release --features=bundled-openssl,bundled-sqlite"
 
-          - os-name: Linux-Android
-            runs-on: ubuntu-22.04
-            target: aarch64-linux-android
-            command: build
-            args: "--release --features=bundled-openssl,bundled-sqlite"
+          # gh -R iesahin/xvc run view 12525734325 --log-failed
+          # - os-name: Linux-Android
+          #   runs-on: ubuntu-22.04
+          #   target: aarch64-linux-android
+          #   command: build
+          #   args: "--release --features=bundled-openssl,bundled-sqlite"
 
           # gh -R iesahin/xvc run view 12525597866 --log-failed
           # - os-name: NetBSD-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,27 @@ jobs:
             command: build
             args: "--release --features=bundled-openssl"
 
+          - os-name: Linux-aarch64
+            runs-on: ubuntu-22.04
+            target: aarch64-unknown-linux-musl
+            command: build
+            args: "--release --features=bundled-openssl"
+
+          - os-name: NetBSD-x86_64
+            runs-on: ubuntu-22.04
+            target: x86_64-unknown-netbsd
+            command: build
+            args: "--release --features=bundled-openssl"
+
           - os-name: Windows-x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc
+            command: build
+            args: "--release --features=bundled-sqlite"
+
+          - os-name: Windows-aarch64
+            runs-on: windows-latest
+            target: aarch64-pc-windows-msvc
             command: build
             args: "--release --features=bundled-sqlite"
 
@@ -52,6 +70,11 @@ jobs:
             command: build
             args: "--release"
 
+          - os-name: macOS-aarch64
+            runs-on: macOS-latest
+            target: aarch64-apple-darwin
+            command: build
+            args: "--release"
           # more targets here ...
 
     runs-on: ${{ matrix.platform.runs-on }}
@@ -69,4 +92,5 @@ jobs:
         uses: houseabsolute/actions-rust-release@v0
         with:
           executable-name: xvc
+          changes-file: "CHANGELOG.md"
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
-          args: "--locked --release"
+          args: "--release"
           strip: true
       - name: Publish artifacts and release
         uses: houseabsolute/actions-rust-release@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,32 +20,37 @@ jobs:
             runs-on: ubuntu-20.04
             target: x86_64-unknown-freebsd
             command: build
-            skip_tests: true
+            args: "--release --features=bundled-openssl"
 
           - os-name: Linux-x86_64
             runs-on: ubuntu-20.04
             target: x86_64-unknown-linux-musl
             command: build
+            args: "--release --features=bundled-openssl"
 
           - os-name: Linux-aarch64
             runs-on: ubuntu-20.04
             target: aarch64-unknown-linux-musl
             command: build
+            args: "--release --features=bundled-openssl"
 
           - os-name: Linux-riscv64
             runs-on: ubuntu-20.04
             target: riscv64gc-unknown-linux-gnu
             command: build
+            args: "--release --features=bundled-openssl"
 
           - os-name: Windows-x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc
             command: build
+            args: "--release --features=bundled-sqlite"
 
           - os-name: macOS-x86_64
             runs-on: macOS-latest
             target: x86_64-apple-darwin
             command: build
+            args: "--release"
 
           # more targets here ...
 
@@ -58,7 +63,7 @@ jobs:
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
-          args: "--release"
+          args: ${{ matrix.platform.args }}
           strip: true
       - name: Publish artifacts and release
         uses: houseabsolute/actions-rust-release@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,30 +16,36 @@ jobs:
     strategy:
       matrix:
         platform:
-          # - os-name: FreeBSD-x86_64
-          #   runs-on: ubuntu-20.04
-          #   target: x86_64-unknown-freebsd
-          #   skip_tests: true
+          - os-name: FreeBSD-x86_64
+            runs-on: ubuntu-20.04
+            target: x86_64-unknown-freebsd
+            command: build
+            skip_tests: true
 
           - os-name: Linux-x86_64
             runs-on: ubuntu-20.04
             target: x86_64-unknown-linux-musl
+            command: build
 
           - os-name: Linux-aarch64
             runs-on: ubuntu-20.04
             target: aarch64-unknown-linux-musl
+            command: build
 
           - os-name: Linux-riscv64
             runs-on: ubuntu-20.04
             target: riscv64gc-unknown-linux-gnu
+            command: build
 
           - os-name: Windows-x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc
+            command: build
 
           - os-name: macOS-x86_64
             runs-on: macOS-latest
             target: x86_64-apple-darwin
+            command: build
 
           # more targets here ...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,12 @@ jobs:
             command: build
             args: "--release --features=bundled-openssl"
 
-          - os-name: Linux-riscv64
-            runs-on: ubuntu-20.04
-            target: riscv64gc-unknown-linux-gnu
-            command: build
-            args: "--release --features=bundled-openssl"
+          # FIXME: OpenSSL Compilation Errors
+          # - os-name: Linux-riscv64
+          #   runs-on: ubuntu-20.04
+          #   target: riscv64gc-unknown-linux-gnu
+          #   command: build
+          #   args: "--release --features=bundled-openssl"
 
           - os-name: Linux-aarch64
             runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             runs-on: ubuntu-20.04
             target: aarch64-unknown-linux-musl
             command: build
-            args: "--release --features=bundled-openssl"
+            args: "--release --features=bundled-openssl,bundled-sqlite"
 
           # FIXME: OpenSSL Compilation Errors
           # - os-name: Linux-riscv64
@@ -45,7 +45,13 @@ jobs:
             runs-on: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             command: build
-            args: "--release --features=bundled-openssl"
+            args: "--release --features=bundled-openssl,bundled-sqlite"
+
+          - os-name: Linux-Android
+            runs-on: ubuntu-22.04
+            target: aarch64-linux-android
+            command: build
+            args: "--release --features=bundled-openssl,bundled-sqlite"
 
           # gh -R iesahin/xvc run view 12525597866 --log-failed
           # - os-name: NetBSD-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,5 +57,5 @@ jobs:
       - name: Publish artifacts and release
         uses: houseabsolute/actions-rust-release@v0
         with:
-          executable-name: ubi
+          executable-name: xvc
           target: ${{ matrix.platform.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,121 +132,121 @@ jobs:
         if: matrix.benches
         run: cargo test --benches ${{ matrix.features }}
 
-  deploy-linux:
-    name: deploy-linux
-    needs: [coverage]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          [
-            x86_64-unknown-linux-gnu,
-            aarch64-unknown-linux-gnu,
-            aarch64-linux-android,
-          ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-
-      - name: Build target
-        run: cargo build --release --target ${{ matrix.target }} --features=bundled-openssl
-
-      - name: Package
-        shell: bash
-        run: |
-          #strip target/${{ matrix.target }}/release/xvc
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../xvc-${{ github.ref_name }}-${{ matrix.target }}.tar.gz xvc
-          cd -
-
-      - name: Publish
-        uses: softprops/action-gh-release@v1
-        # TODO: if any of the build step fails, the release should be deleted.
-        with:
-          files: "xvc*"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy-windows:
-    name: deploy-windows
-    needs: [coverage]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        target: [x86_64-pc-windows-gnu]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-
-      - name: Build target
-        run: cargo build --release --target ${{ matrix.target }} --features bundled-sqlite
-
-      - name: Package
-        shell: bash
-        run: |
-          #strip target/${{ matrix.target }}/release/xvc
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../xvc-${{ github.ref_name}}-${{ matrix.target }}.tar.gz xvc
-          cd -
-
-      - name: Publish
-        uses: softprops/action-gh-release@v1
-        # TODO: if any of the build step fails, the release should be deleted.
-        with:
-          files: "xvc*"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy-macos:
-    name: deploy-macos
-    needs: [coverage]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        target:
-          [x86_64-apple-darwin, aarch64-apple-darwin, x86_64-unknown-freebsd]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-
-      - name: Build target
-        run: cargo build --release --target ${{ matrix.target }}
-
-      - name: Package
-        shell: bash
-        run: |
-          #strip target/${{ matrix.target }}/release/xvc
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../xvc-${{ github.ref_name}}-${{ matrix.target }}.tar.gz xvc
-          cd -
-
-      - name: Publish
-        uses: softprops/action-gh-release@v1
-        # TODO: if any of the build step fails, the release should be deleted.
-        with:
-          files: "xvc*"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # deploy-linux:
+  #   name: deploy-linux
+  #   needs: [coverage]
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         [
+  #           x86_64-unknown-linux-gnu,
+  #           aarch64-unknown-linux-gnu,
+  #           aarch64-linux-android,
+  #         ]
+  #
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
+  #
+  #     - name: Install rust
+  #       uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: stable
+  #         targets: ${{ matrix.target }}
+  #
+  #     - name: Build target
+  #       run: cargo build --release --target ${{ matrix.target }} --features=bundled-openssl
+  #
+  #     - name: Package
+  #       shell: bash
+  #       run: |
+  #         #strip target/${{ matrix.target }}/release/xvc
+  #         cd target/${{ matrix.target }}/release
+  #         tar czvf ../../../xvc-${{ github.ref_name }}-${{ matrix.target }}.tar.gz xvc
+  #         cd -
+  #
+  #     - name: Publish
+  #       uses: softprops/action-gh-release@v1
+  #       # TODO: if any of the build step fails, the release should be deleted.
+  #       with:
+  #         files: "xvc*"
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #
+  # deploy-windows:
+  #   name: deploy-windows
+  #   needs: [coverage]
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       target: [x86_64-pc-windows-gnu]
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
+  #
+  #     - name: Install rust
+  #       uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: stable
+  #         targets: ${{ matrix.target }}
+  #
+  #     - name: Build target
+  #       run: cargo build --release --target ${{ matrix.target }} --features bundled-sqlite
+  #
+  #     - name: Package
+  #       shell: bash
+  #       run: |
+  #         #strip target/${{ matrix.target }}/release/xvc
+  #         cd target/${{ matrix.target }}/release
+  #         tar czvf ../../../xvc-${{ github.ref_name}}-${{ matrix.target }}.tar.gz xvc
+  #         cd -
+  #
+  #     - name: Publish
+  #       uses: softprops/action-gh-release@v1
+  #       # TODO: if any of the build step fails, the release should be deleted.
+  #       with:
+  #         files: "xvc*"
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #
+  # deploy-macos:
+  #   name: deploy-macos
+  #   needs: [coverage]
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         [x86_64-apple-darwin, aarch64-apple-darwin, x86_64-unknown-freebsd]
+  #
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v1
+  #
+  #     - name: Install rust
+  #       uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: stable
+  #         targets: ${{ matrix.target }}
+  #
+  #     - name: Build target
+  #       run: cargo build --release --target ${{ matrix.target }}
+  #
+  #     - name: Package
+  #       shell: bash
+  #       run: |
+  #         #strip target/${{ matrix.target }}/release/xvc
+  #         cd target/${{ matrix.target }}/release
+  #         tar czvf ../../../xvc-${{ github.ref_name}}-${{ matrix.target }}.tar.gz xvc
+  #         cd -
+  #
+  #     - name: Publish
+  #       uses: softprops/action-gh-release@v1
+  #       # TODO: if any of the build step fails, the release should be deleted.
+  #       with:
+  #         files: "xvc*"
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 
 ## v0.6.13 (2024-12-29)
 
+- PR: <https://github.com/iesahin/xvc/pull/263>
 - Removed reflink from default features
 - Hide directories in xvc file list output by default and add --show-dirs option
-- Set core.quotepath=off in git ls-files call to get paths in UTF-8 to matchh
+- Set core.quotepath=off in git ls-files call to get paths in UTF-8 to match
 - Handle missing files in xvc file bring more gracefully
 - Fixed git version string to also consider lightweight tags
 - Fixed xvc file remove bug that panics when content digests not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 
-## v0.6.13 (2024-12-29)
+## v0.6.13 (2024-12-30)
 
 - PR: <https://github.com/iesahin/xvc/pull/263>
 - Removed reflink from default features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## v0.6.13
+
 - Hide directories in xvc file list output by default and add --show-dirs option
 - Set core.quotepath=off in git ls-files call to get paths in UTF-8 to matchh
 - Handle missing files in xvc file bring more gracefully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## v0.6.13 (2024-12-28)
 
+- Removed reflink from default features
 - Hide directories in xvc file list output by default and add --show-dirs option
 - Set core.quotepath=off in git ls-files call to get paths in UTF-8 to matchh
 - Handle missing files in xvc file bring more gracefully

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 
-## v0.6.13
+## v0.6.13 (2024-12-28)
 
 - Hide directories in xvc file list output by default and add --show-dirs option
 - Set core.quotepath=off in git ls-files call to get paths in UTF-8 to matchh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Set core.quotepath=off in git ls-files call to get paths in UTF-8 to match
+- Hide directories in xvc file list output by default and add --show-dirs option
+- Set core.quotepath=off in git ls-files call to get paths in UTF-8 to matchh
 - Handle missing files in xvc file bring more gracefully
 - Fixed git version string to also consider lightweight tags
 - Fixed xvc file remove bug that panics when content digests not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 
-## v0.6.13 (2024-12-28)
+## v0.6.13 (2024-12-29)
 
 - Removed reflink from default features
 - Hide directories in xvc file list output by default and add --show-dirs option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle missing files in xvc file bring more gracefully
 - Fixed git version string to also consider lightweight tags
 - Fixed xvc file remove bug that panics when content digests not found
 - Fixed xvc file list help text and added a test/example for ignored files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed xvc file remove bug that panics when content digests not found
 - Fixed xvc file list help text and added a test/example for ignored files
 - Added more targets to Github builds
+- Releases now use houseabsolute/actions-rust-cross@v0
 
 ## 0.6.12 (2024-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Set core.quotepath=off in git ls-files call to get paths in UTF-8 to match
 - Handle missing files in xvc file bring more gracefully
 - Fixed git version string to also consider lightweight tags
 - Fixed xvc file remove bug that panics when content digests not found

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -172,7 +172,7 @@ FH          19 [..] c85f3e81 c85f3e81 another-set/data3.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data2.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data.txt
 
-Total #: 8 Workspace Size:         278 Cached Size:          19
+Total #: 8 Workspace Size:         276 Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -172,7 +172,7 @@ FH          19 [..] c85f3e81 c85f3e81 another-set/data3.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data2.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data.txt
 
-Total #: 8 Workspace Size:         276 Cached Size:          19
+Total #: 8 Workspace Size:         278 Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -171,9 +171,8 @@ XC             [..] c85f3e81          data.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data3.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data2.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data.txt
-DX         160 [..]                   another-set
 
-Total #: 9 Workspace Size:       [..] Cached Size:          19
+Total #: 8 Workspace Size:         278 Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-copy.md
+++ b/book/src/ref/xvc-file-copy.md
@@ -172,7 +172,7 @@ FH          19 [..] c85f3e81 c85f3e81 another-set/data3.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data2.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data.txt
 
-Total #: 8 Workspace Size:         278 Cached Size:          19
+Total #: 8 Workspace Size:        [..] Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-list.md
+++ b/book/src/ref/xvc-file-list.md
@@ -53,7 +53,12 @@ Options:
           
           The default option can be set with file.list.no_summary in the config file.
 
-  -a, --show-dot-files
+  -d, --show-directories
+          Don't hide directories
+          
+          Directories are not listed by default. This flag lists them.
+
+  -D, --show-dot-files
           Don't hide dot files
           
           If not supplied, hides dot files like .gitignore and .xvcignore
@@ -71,7 +76,7 @@ Options:
 ## Examples
 
 For these examples, we'll create a directory tree with five directories, each
-having a file.
+having 5 files.
 
 ```console
 $ xvc-test-helper create-directory-tree --directories 5 --files 5 --seed 20230213
@@ -134,45 +139,51 @@ $ xvc init
 
 ```
 
-Now it lists all files and directories.
+Now it lists all files
 
 ```console
 $ xvc file list --sort name-asc
-DX         224 [..]                   dir-0001
-FX        2001 [..]          1953f05d dir-0001/file-0001.bin
-FX        2002 [..]          7e807161 dir-0001/file-0002.bin
-FX        2003 [..]          d2432259 dir-0001/file-0003.bin
-FX        2004 [..]          63535612 dir-0001/file-0004.bin
-FX        2005 [..]          447933dc dir-0001/file-0005.bin
-DX         224 [..]                   dir-0002
-FX        2001 [..]          1953f05d dir-0002/file-0001.bin
-FX        2002 [..]          7e807161 dir-0002/file-0002.bin
-FX        2003 [..]          d2432259 dir-0002/file-0003.bin
-FX        2004 [..]          63535612 dir-0002/file-0004.bin
-FX        2005 [..]          447933dc dir-0002/file-0005.bin
-DX         224 [..]                   dir-0003
-FX        2001 [..]          1953f05d dir-0003/file-0001.bin
-FX        2002 [..]          7e807161 dir-0003/file-0002.bin
-FX        2003 [..]          d2432259 dir-0003/file-0003.bin
-FX        2004 [..]          63535612 dir-0003/file-0004.bin
-FX        2005 [..]          447933dc dir-0003/file-0005.bin
-DX         224 [..]                   dir-0004
-FX        2001 [..]          1953f05d dir-0004/file-0001.bin
-FX        2002 [..]          7e807161 dir-0004/file-0002.bin
-FX        2003 [..]          d2432259 dir-0004/file-0003.bin
-FX        2004 [..]          63535612 dir-0004/file-0004.bin
-FX        2005 [..]          447933dc dir-0004/file-0005.bin
-DX         224 [..]                   dir-0005
-FX        2001 [..]          1953f05d dir-0005/file-0001.bin
-FX        2002 [..]          7e807161 dir-0005/file-0002.bin
-FX        2003 [..]          d2432259 dir-0005/file-0003.bin
-FX        2004 [..]          63535612 dir-0005/file-0004.bin
-FX        2005 [..]          447933dc dir-0005/file-0005.bin
+FX        [..]          1953f05d dir-0001/file-0001.bin
+FX        [..]          7e807161 dir-0001/file-0002.bin
+FX        [..]          d2432259 dir-0001/file-0003.bin
+FX        [..]          63535612 dir-0001/file-0004.bin
+FX        [..]          447933dc dir-0001/file-0005.bin
+FX        [..]          1953f05d dir-0002/file-0001.bin
+FX        [..]          7e807161 dir-0002/file-0002.bin
+FX        [..]          d2432259 dir-0002/file-0003.bin
+FX        [..]          63535612 dir-0002/file-0004.bin
+FX        [..]          447933dc dir-0002/file-0005.bin
+FX        [..]          1953f05d dir-0003/file-0001.bin
+FX        [..]          7e807161 dir-0003/file-0002.bin
+FX        [..]          d2432259 dir-0003/file-0003.bin
+FX        [..]          63535612 dir-0003/file-0004.bin
+FX        [..]          447933dc dir-0003/file-0005.bin
+FX        [..]          1953f05d dir-0004/file-0001.bin
+FX        [..]          7e807161 dir-0004/file-0002.bin
+FX        [..]          d2432259 dir-0004/file-0003.bin
+FX        [..]          63535612 dir-0004/file-0004.bin
+FX        [..]          447933dc dir-0004/file-0005.bin
+FX        [..]          1953f05d dir-0005/file-0001.bin
+FX        [..]          7e807161 dir-0005/file-0002.bin
+FX        [..]          d2432259 dir-0005/file-0003.bin
+FX        [..]          63535612 dir-0005/file-0004.bin
+FX        [..]          447933dc dir-0005/file-0005.bin
 
-Total #: 30 Workspace Size:       51195 Cached Size:           0
+Total #: 25 Workspace Size:       50075 Cached Size:           0
 
 
 ```
+
+## Listing Directories
+
+`xvc file list` doesn't list directories by default. If you want to list them, you can use `--show-directories`/`-d` flag.
+
+
+```console
+$ xvc file list --show_directories
+```
+
+
 
 ## Files tracked by Git
 
@@ -219,31 +230,26 @@ By default the command hides dotfiles too. If you also want to show them, you ca
 $ xvc file list --sort name-asc --show-dot-files --include-git-files
 FX         107 [..]          ce9fcf30 .gitignore
 FX         141 [..]          3054b812 .xvcignore
-DX         224 [..]                   dir-0001
 FX        2001 [..]          1953f05d dir-0001/file-0001.bin
 FX        2002 [..]          7e807161 dir-0001/file-0002.bin
 FX        2003 [..]          d2432259 dir-0001/file-0003.bin
 FX        2004 [..]          63535612 dir-0001/file-0004.bin
 FX        2005 [..]          447933dc dir-0001/file-0005.bin
-DX         224 [..]                   dir-0002
 FX        2001 [..]          1953f05d dir-0002/file-0001.bin
 FX        2002 [..]          7e807161 dir-0002/file-0002.bin
 FX        2003 [..]          d2432259 dir-0002/file-0003.bin
 FX        2004 [..]          63535612 dir-0002/file-0004.bin
 FX        2005 [..]          447933dc dir-0002/file-0005.bin
-DX         224 [..]                   dir-0003
 FX        2001 [..]          1953f05d dir-0003/file-0001.bin
 FX        2002 [..]          7e807161 dir-0003/file-0002.bin
 FX        2003 [..]          d2432259 dir-0003/file-0003.bin
 FX        2004 [..]          63535612 dir-0003/file-0004.bin
 FX        2005 [..]          447933dc dir-0003/file-0005.bin
-DX         224 [..]                   dir-0004
 FX        2001 [..]          1953f05d dir-0004/file-0001.bin
 FX        2002 [..]          7e807161 dir-0004/file-0002.bin
 FX        2003 [..]          d2432259 dir-0004/file-0003.bin
 FX        2004 [..]          63535612 dir-0004/file-0004.bin
 FX        2005 [..]          447933dc dir-0004/file-0005.bin
-DX         224 [..]                   dir-0005
 FX        2001 [..]          1953f05d dir-0005/file-0001.bin
 FX        2002 [..]          7e807161 dir-0005/file-0002.bin
 FX        2003 [..]          d2432259 dir-0005/file-0003.bin
@@ -259,32 +265,27 @@ Total #: 33 Workspace Size:       51455 Cached Size:           0
 You can also hide the summary below the list to get only the list of files.
 
 ```console
-$ xvc file list  --sort name-asc --no-summary
 DX         224 [..]                   dir-0001
 FX        2001 [..]          1953f05d dir-0001/file-0001.bin
 FX        2002 [..]          7e807161 dir-0001/file-0002.bin
 FX        2003 [..]          d2432259 dir-0001/file-0003.bin
 FX        2004 [..]          63535612 dir-0001/file-0004.bin
 FX        2005 [..]          447933dc dir-0001/file-0005.bin
-DX         224 [..]                   dir-0002
 FX        2001 [..]          1953f05d dir-0002/file-0001.bin
 FX        2002 [..]          7e807161 dir-0002/file-0002.bin
 FX        2003 [..]          d2432259 dir-0002/file-0003.bin
 FX        2004 [..]          63535612 dir-0002/file-0004.bin
 FX        2005 [..]          447933dc dir-0002/file-0005.bin
-DX         224 [..]                   dir-0003
 FX        2001 [..]          1953f05d dir-0003/file-0001.bin
 FX        2002 [..]          7e807161 dir-0003/file-0002.bin
 FX        2003 [..]          d2432259 dir-0003/file-0003.bin
 FX        2004 [..]          63535612 dir-0003/file-0004.bin
 FX        2005 [..]          447933dc dir-0003/file-0005.bin
-DX         224 [..]                   dir-0004
 FX        2001 [..]          1953f05d dir-0004/file-0001.bin
 FX        2002 [..]          7e807161 dir-0004/file-0002.bin
 FX        2003 [..]          d2432259 dir-0004/file-0003.bin
 FX        2004 [..]          63535612 dir-0004/file-0004.bin
 FX        2005 [..]          447933dc dir-0004/file-0005.bin
-DX         224 [..]                   dir-0005
 FX        2001 [..]          1953f05d dir-0005/file-0001.bin
 FX        2002 [..]          7e807161 dir-0005/file-0002.bin
 FX        2003 [..]          d2432259 dir-0005/file-0003.bin
@@ -514,26 +515,22 @@ dir-0004/file-0004.bin
 dir-0004/file-0003.bin
 dir-0004/file-0002.bin
 dir-0004/file-0001.bin
-dir-0004
 dir-0003/file-0005.bin
 dir-0003/file-0004.bin
 dir-0003/file-0003.bin
 dir-0003/file-0002.bin
 dir-0003/file-0001.bin
-dir-0003
 dir-0002/file-0005.bin
 dir-0002/file-0004.bin
 dir-0002/file-0003.bin
 dir-0002/file-0002.bin
 dir-0002/file-0001.bin
-dir-0002
 dir-0001/file-0005.bin
 dir-0001/file-0004.bin
 dir-0001/file-0003.bin
 dir-0001/file-0002.bin
 dir-0001/file-0001.bin
 dir-0001/a-new-file.bin
-dir-0001
 
 
 ```

--- a/book/src/ref/xvc-file-list.md
+++ b/book/src/ref/xvc-file-list.md
@@ -181,14 +181,39 @@ Total #: 25 Workspace Size:       50075 Cached Size:           0
 
 ```console
 $ xvc file list --show-directories
-? 2
-error: unexpected argument '--show_directories' found
+FX        2005 [..]          447933dc dir-0005/file-0005.bin
+FX        2004 [..]          63535612 dir-0005/file-0004.bin
+FX        2003 [..]          d2432259 dir-0005/file-0003.bin
+FX        2002 [..]          7e807161 dir-0005/file-0002.bin
+FX        2001 [..]          1953f05d dir-0005/file-0001.bin
+DX         224 [..]                   dir-0005
+FX        2005 [..]          447933dc dir-0004/file-0005.bin
+FX        2004 [..]          63535612 dir-0004/file-0004.bin
+FX        2003 [..]          d2432259 dir-0004/file-0003.bin
+FX        2002 [..]          7e807161 dir-0004/file-0002.bin
+FX        2001 [..]          1953f05d dir-0004/file-0001.bin
+DX         224 [..]                   dir-0004
+FX        2005 [..]          447933dc dir-0003/file-0005.bin
+FX        2004 [..]          63535612 dir-0003/file-0004.bin
+FX        2003 [..]          d2432259 dir-0003/file-0003.bin
+FX        2002 [..]          7e807161 dir-0003/file-0002.bin
+FX        2001 [..]          1953f05d dir-0003/file-0001.bin
+DX         224 [..]                   dir-0003
+FX        2005 [..]          447933dc dir-0002/file-0005.bin
+FX        2004 [..]          63535612 dir-0002/file-0004.bin
+FX        2003 [..]          d2432259 dir-0002/file-0003.bin
+FX        2002 [..]          7e807161 dir-0002/file-0002.bin
+FX        2001 [..]          1953f05d dir-0002/file-0001.bin
+DX         224 [..]                   dir-0002
+FX        2005 [..]          447933dc dir-0001/file-0005.bin
+FX        2004 [..]          63535612 dir-0001/file-0004.bin
+FX        2003 [..]          d2432259 dir-0001/file-0003.bin
+FX        2002 [..]          7e807161 dir-0001/file-0002.bin
+FX        2001 [..]          1953f05d dir-0001/file-0001.bin
+DX         224 [..]                   dir-0001
 
-  tip: a similar argument exists: '--show-directories'
+Total #: 30 Workspace Size:       51195 Cached Size:           0
 
-Usage: xvc file list <--format <FORMAT>|--sort <SORT>|--no-summary|--show-directories|--show-dot-files|--include-git-files|TARGETS>
-
-For more information, try '--help'.
 
 ```
 
@@ -274,7 +299,7 @@ Total #: 28 Workspace Size:       50335 Cached Size:           0
 You can also hide the summary below the list to get only the list of files.
 
 ```console
-$ xvc file list --no-summary
+$ xvc file list --no-summary --sort name-asc
 FX        2001 [..]          1953f05d dir-0001/file-0001.bin
 FX        2002 [..]          7e807161 dir-0001/file-0002.bin
 FX        2003 [..]          d2432259 dir-0001/file-0003.bin

--- a/book/src/ref/xvc-file-list.md
+++ b/book/src/ref/xvc-file-list.md
@@ -180,7 +180,16 @@ Total #: 25 Workspace Size:       50075 Cached Size:           0
 
 
 ```console
-$ xvc file list --show_directories
+$ xvc file list --show-directories
+? 2
+error: unexpected argument '--show_directories' found
+
+  tip: a similar argument exists: '--show-directories'
+
+Usage: xvc file list <--format <FORMAT>|--sort <SORT>|--no-summary|--show-directories|--show-dot-files|--include-git-files|TARGETS>
+
+For more information, try '--help'.
+
 ```
 
 
@@ -257,7 +266,7 @@ FX        2004 [..]          63535612 dir-0005/file-0004.bin
 FX        2005 [..]          447933dc dir-0005/file-0005.bin
 FX          12 [..]          6ecb3ffc my-git-tracked-script.sh
 
-Total #: 33 Workspace Size:       51455 Cached Size:           0
+Total #: 28 Workspace Size:       50335 Cached Size:           0
 
 
 ```

--- a/book/src/ref/xvc-file-list.md
+++ b/book/src/ref/xvc-file-list.md
@@ -174,6 +174,8 @@ Total #: 30 Workspace Size:       51195 Cached Size:           0
 
 ```
 
+## Files tracked by Git
+
 This command doesn't list Git-tracked files by default. If you want to list them, use `--include-git-files` flag.
 ```console
 $ zsh -c 'echo "#!/bin/bash" > my-git-tracked-script.sh'
@@ -195,6 +197,21 @@ Total #: 1 Workspace Size:          12 Cached Size:           0
 
 
 ```
+
+````admonish warning 
+Xvc detects files tracked by git with the output of `git ls-files`. In default
+configuration Git encodes **UTF-8** file names in octal format. As Xvc uses
+UTF-8 internally to keep track of paths, it cannot identify files are tracked
+by Git if they have non-ASCII characters. 
+
+Please set 
+
+```shell
+git config core.quotepath off
+```
+
+in your Xvc repository to let Git list files in UTF-8.  
+````
 
 By default the command hides dotfiles too. If you also want to show them, you can use `--show-dot-files`/`-a` flag. If you want to show dotfiles also tracked by git, you may use `--show-dot-files` and `--include-git-files` together.
 

--- a/book/src/ref/xvc-file-list.md
+++ b/book/src/ref/xvc-file-list.md
@@ -265,7 +265,7 @@ Total #: 33 Workspace Size:       51455 Cached Size:           0
 You can also hide the summary below the list to get only the list of files.
 
 ```console
-DX         224 [..]                   dir-0001
+$ xvc file list --no-summary
 FX        2001 [..]          1953f05d dir-0001/file-0001.bin
 FX        2002 [..]          7e807161 dir-0001/file-0002.bin
 FX        2003 [..]          d2432259 dir-0001/file-0003.bin

--- a/book/src/ref/xvc-file-move.md
+++ b/book/src/ref/xvc-file-move.md
@@ -122,9 +122,8 @@ $ xvc file move another-set/data5.txt data6.txt --no-recheck
 $ xvc file list
 XH                                 c85f3e81          data6.txt
 FH          19 [..] c85f3e81 c85f3e81 another-set/data4.txt
-DX          96 [..]                   another-set
 
-Total #: 3 Workspace Size:         115 Cached Size:          19
+Total #: 2 Workspace Size:          19 Cached Size:          19
 
 
 ```

--- a/book/src/ref/xvc-file-track.md
+++ b/book/src/ref/xvc-file-track.md
@@ -102,6 +102,29 @@ You can specify more than one target in a single command.
 $ xvc file track dir-0001/file-0002.bin dir-0001/file-0003.bin
 ```
 
+## Files tracked by Git
+
+By default, Xvc doesn't track files tracked by Git. You need to specify
+`--include-git-files` options to track files tracked by git.
+
+````admonish warning 
+Xvc detects files tracked by git with the output of `git ls-files`. In default
+configuration Git encodes **UTF-8** file names in octal format. As Xvc uses
+UTF-8 internally to keep track of paths, it cannot identify files are tracked
+by Git if they have non-ASCII characters. 
+
+Please set 
+
+```shell
+git config core.quotepath off
+```
+
+in your Xvc repository to let Git list files in UTF-8.  
+````
+
+
+## Caching
+
 When you track a file, Xvc moves the file to the cache directory under `.xvc/`
 and _connects_ the workspace file with the cached file. This _connection_ is
 called rechecking and analogous to Git checkout. For example, the above

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
 
 
 ## Cli and config

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
 
 
 ## Cli and config

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
 
 
 ## Cli and config

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
 
 
 ## Cli and config

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -647,7 +647,6 @@ pub fn toml_value_to_hashmap(key: String, value: TomlValue) -> HashMap<String, T
 }
 
 #[cfg(test)]
-
 mod tests {
 
     use super::*;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.1", path = "../config" }
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.1", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
+xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -83,6 +83,6 @@ itertools = "^0.13"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.1", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
 proptest = "^1.5"
 test-case = "^3.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -83,6 +83,6 @@ itertools = "^0.13"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
 proptest = "^1.5"
 test-case = "^3.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-config = { version = "0.6.13-alpha.5", path = "../config" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.5", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -83,6 +83,6 @@ itertools = "^0.13"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.5", path = "../test_helper/" }
 proptest = "^1.5"
 test-case = "^3.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -83,6 +83,6 @@ itertools = "^0.13"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
 proptest = "^1.5"
 test-case = "^3.3"

--- a/core/src/check_ignore/mod.rs
+++ b/core/src/check_ignore/mod.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use log::trace;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use xvc_logging::{output, watch, XvcOutputSender};
+use xvc_logging::{output, XvcOutputSender};
 use xvc_walker::{build_ignore_patterns, IgnoreRules, MatchResult, WalkOptions};
 
 // DIFFERENCES from DVC
@@ -120,7 +120,6 @@ fn check_ignore_paths(
 
 /// Check whether the records match to the full_path. It reports the details if
 /// set true. Non_matching inverts the reporting.
-
 fn check_ignore_line(ignore_rules: &IgnoreRules, absolute_path: &Path) -> String {
     match ignore_rules.check(absolute_path) {
         MatchResult::NoMatch => {

--- a/core/src/check_ignore/mod.rs
+++ b/core/src/check_ignore/mod.rs
@@ -63,16 +63,12 @@ pub fn cmd_check_ignore<R: BufRead>(
         &walk_options.ignore_filename.unwrap_or_default(),
     )?;
 
-    watch!(ignore_rules);
-    watch!(opts.targets);
-
     if !opts.targets.is_empty() {
         let xvc_paths = opts
             .targets
             .iter()
             .map(|p| XvcPath::new(xvc_root, current_dir, &PathBuf::from(p)))
             .collect::<Result<Vec<XvcPath>>>()?;
-        watch!(xvc_paths);
         check_ignore_paths(xvc_root, &ignore_rules, &xvc_paths)
     } else {
         check_ignore_stdin(input, output_snd, xvc_root, &ignore_rules)

--- a/core/src/root/mod.rs
+++ b/core/src/root/mod.rs
@@ -38,7 +38,6 @@ pub fn run(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: RootCLI) -> R
         let rel_dir = RelativePath::new(&current_dir.to_string_lossy()).relative(
             RelativePath::new(&xvc_root.absolute_path().to_string_lossy()),
         );
-        watch!(rel_dir);
         if rel_dir == "" {
             output!(output_snd, ".");
         } else {

--- a/core/src/root/mod.rs
+++ b/core/src/root/mod.rs
@@ -4,7 +4,7 @@ use crate::types::xvcroot::XvcRoot;
 use clap::Parser;
 
 use relative_path::RelativePath;
-use xvc_logging::{output, watch, XvcOutputSender};
+use xvc_logging::{output, XvcOutputSender};
 
 #[derive(Debug, Parser, Clone)]
 #[command(name = "root")]

--- a/core/src/types/diff.rs
+++ b/core/src/types/diff.rs
@@ -291,8 +291,6 @@ pub trait Diffable {
     /// For example, a file may be missing from the disk, but it may exist in the records.
     /// ((Some(record), None) -> Diff::ActualMissing)
     fn diff(record: Option<&Self::Item>, actual: Option<&Self::Item>) -> Diff<Self::Item> {
-        watch!(record);
-        watch!(actual);
         match (record, actual) {
             (None, None) => unreachable!("Both record and actual are None"),
             (None, Some(actual)) => Diff::RecordMissing {

--- a/core/src/types/diff.rs
+++ b/core/src/types/diff.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use crate::Result;
 use serde::{Deserialize, Serialize};
 use xvc_ecs::{HStore, Storable, XvcEntity, XvcStore};
-use xvc_logging::{warn, watch};
+use xvc_logging::warn;
 
 /// Shows which information is identical, missing or different in diff calculations.
 ///

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -114,7 +114,7 @@ impl XvcPath {
 
     /// Checks whether this path starts with the given string
     pub fn starts_with_str(&self, base: &str) -> bool {
-        self.0.starts_with(base)
+        self.0.as_str().starts_with(base)
     }
 
     /// Checks whether this path contains the given string

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -112,6 +112,16 @@ impl XvcPath {
         self.0.starts_with(AsRef::<RelativePath>::as_ref(other))
     }
 
+    /// Checks whether this path starts with the given string
+    pub fn starts_with_str(&self, base: &str) -> bool {
+        self.0.starts_with(base)
+    }
+
+    /// Checks whether this path contains the given string
+    pub fn contains(&self, s: &str) -> bool {
+        self.0.as_str().contains(s)
+    }
+
     /// Calculates the content digest of the path
     pub fn digest(
         &self,

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -85,9 +85,6 @@ impl XvcPath {
         }
 
         let abs_path = path.absolutize_from(current_dir)?;
-        xvc_logging::watch!(abs_path);
-        xvc_logging::watch!(current_dir);
-        xvc_logging::watch!(xvc_root.absolute_path());
         let rel_path = abs_path.strip_prefix(xvc_root.absolute_path())?;
         Ok(XvcPath(RelativePathBuf::from_path(rel_path)?))
     }
@@ -289,11 +286,9 @@ impl XvcCachePath {
     #[allow(clippy::permissions_set_readonly_false)]
     pub fn remove(&self, output_snd: &XvcOutputSender, xvc_root: &XvcRoot) -> Result<()> {
         let abs_cp = self.to_absolute_path(xvc_root);
-        watch!(abs_cp);
         if abs_cp.exists() {
             // Set to writable
             let parent = abs_cp.parent().unwrap();
-            watch!(parent);
             let mut dir_perm = parent.metadata()?.permissions();
             dir_perm.set_readonly(false);
             fs::set_permissions(parent, dir_perm)?;
@@ -307,10 +302,8 @@ impl XvcCachePath {
         }
 
         let mut rel_path = self.inner();
-        watch!(rel_path);
         while let Some(parent) = rel_path.parent() {
             let parent_abs_cp = parent.to_logical_path(xvc_root.xvc_dir());
-            watch!(parent_abs_cp);
             if parent_abs_cp.exists()
                 && parent_abs_cp.is_dir()
                 && parent_abs_cp.read_dir().unwrap().count() == 0

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -13,7 +13,7 @@ use path_absolutize::*;
 use relative_path::{RelativePath, RelativePathBuf};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
-use xvc_logging::{output, uwr, watch, XvcOutputSender};
+use xvc_logging::{output, uwr, XvcOutputSender};
 use xvc_walker::AbsolutePath;
 
 use std::ops::Deref;

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use xvc_ecs::ecs::timestamp;
 use xvc_ecs::{XvcEntity, XvcEntityGenerator};
-use xvc_logging::watch;
 use xvc_walker::AbsolutePath;
 
 use xvc_config::{XvcConfig, XvcConfigParams};

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -255,9 +255,7 @@ impl XvcRootInner {
 
         for parent in abs_path.ancestors() {
             let xvc_candidate = parent.join(XVC_DIR);
-            watch!(xvc_candidate);
             if parent.join(XVC_DIR).is_dir() {
-                watch!(parent);
                 return Ok(parent.into());
             }
         }

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -254,7 +254,6 @@ impl XvcRootInner {
             .expect("Cannot canonicalize the path. Possible symlink loop.");
 
         for parent in abs_path.ancestors() {
-            let xvc_candidate = parent.join(XVC_DIR);
             if parent.join(XVC_DIR).is_dir() {
                 return Ok(parent.into());
             }

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -73,13 +73,8 @@ pub fn load_xvc_root(config_opts: XvcConfigParams) -> Result<XvcRoot> {
     let path = config_opts.current_dir.as_ref();
 
     match XvcRootInner::find_root(path) {
-        Ok(absolute_path) => {
-            Ok(Arc::new(XvcRootInner::new(absolute_path, config_opts)?))
-        }
-        Err(e) => {
-            watch!(&e);
-            Err(e)
-        }
+        Ok(absolute_path) => Ok(Arc::new(XvcRootInner::new(absolute_path, config_opts)?)),
+        Err(e) => Err(e),
     }
 }
 
@@ -268,7 +263,6 @@ impl XvcRootInner {
         }
         Err(Error::CannotFindXvcRoot { path: path.into() })
     }
-
 
     /// Record the entity generator to the disk
     pub fn record(&self) {

--- a/core/src/util/file.rs
+++ b/core/src/util/file.rs
@@ -12,7 +12,6 @@ use std::os::windows::fs as windows_fs;
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
-use xvc_logging::watch;
 use xvc_walker::{IgnoreRules, PathMetadata, SharedIgnoreRules, WalkOptions};
 
 use crate::error::Error;

--- a/core/src/util/file.rs
+++ b/core/src/util/file.rs
@@ -21,9 +21,6 @@ use crate::CHANNEL_BOUND;
 
 use crossbeam_channel::{bounded, Receiver, Sender};
 
-
-
-
 use crate::types::{xvcpath::XvcPath, xvcroot::XvcRoot};
 
 use super::pmp::XvcPathMetadataProvider;
@@ -47,12 +44,7 @@ pub fn path_metadata_channel(sender: Sender<Result<PathMetadata>>, start_dir: &P
     let ignore_rules = Arc::new(RwLock::new(IgnoreRules::empty(start_dir, None)));
     let (w_sender, w_receiver) = bounded(CHANNEL_BOUND);
 
-    xvc_walker::walk_parallel::walk_parallel(
-        ignore_rules,
-        start_dir,
-        walk_options,
-        w_sender,
-    )?;
+    xvc_walker::walk_parallel::walk_parallel(ignore_rules, start_dir, walk_options, w_sender)?;
     for pm in w_receiver {
         sender.send(Ok(pm?))?;
     }
@@ -102,7 +94,6 @@ pub fn glob_paths(
     glob: &str,
 ) -> Result<XvcPathMetadataMap> {
     let full_glob = format!("{}{}", root_dir, glob);
-    watch!(full_glob);
     pmp.glob_paths(&full_glob)
 }
 

--- a/core/src/util/git.rs
+++ b/core/src/util/git.rs
@@ -3,7 +3,7 @@ use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
 use crate::XvcRoot;
 use subprocess::Exec;
-use xvc_logging::{debug, watch, XvcOutputSender};
+use xvc_logging::{debug, XvcOutputSender};
 
 use crate::{Error, Result};
 use std::path::Path;
@@ -303,7 +303,6 @@ mod test {
     use super::*;
     use std::fs;
     use test_case::test_case;
-    use xvc_logging::watch;
     use xvc_test_helper::*;
     use xvc_walker::MatchResult as M;
 

--- a/core/src/util/git.rs
+++ b/core/src/util/git.rs
@@ -64,7 +64,6 @@ pub fn exec_git(git_command: &str, xvc_directory: &str, args_str_vec: &[&str]) -
         .iter()
         .map(|s| OsString::from_str(s).unwrap())
         .collect();
-    watch!(args);
     let proc_res = Exec::cmd(git_command).args(&args).capture()?;
 
     match proc_res.exit_status {
@@ -95,7 +94,6 @@ pub fn get_git_tracked_files(git_command: &str, xvc_directory: &str) -> Result<V
         // it to off.
         &["-c", "core.quotepath=off", "ls-files", "--full-name"],
     )?;
-    watch!(git_ls_files_out);
     let git_ls_files_out = git_ls_files_out
         .lines()
         .map(|s| s.to_string())
@@ -115,8 +113,6 @@ pub fn stash_user_staged_files(
         xvc_directory,
         &["diff", "--name-only", "--cached"],
     )?;
-
-    watch!(git_diff_staged_out);
 
     // If so stash them
     if !git_diff_staged_out.trim().is_empty() {
@@ -234,7 +230,6 @@ pub fn git_auto_commit(
         ],
     ) {
         Ok(git_add_output) => {
-            watch!(git_add_output);
             if git_add_output.trim().is_empty() {
                 debug!(output_snd, "No files to commit");
                 return Ok(());
@@ -324,22 +319,14 @@ mod test {
     fn test_gitignore(path: &str, gitignore_path: &str, ignore_line: &str) -> M {
         test_logging(log::LevelFilter::Trace);
         let git_root = temp_git_dir();
-        watch!(git_root);
         let path = git_root.join(PathBuf::from(path));
-        watch!(path);
         let gitignore_path = git_root.join(PathBuf::from(gitignore_path));
-        watch!(gitignore_path);
         if let Some(ignore_dir) = gitignore_path.parent() {
-            watch!(ignore_dir);
             fs::create_dir_all(ignore_dir).unwrap();
-            watch!(ignore_dir.exists());
         }
         fs::write(&gitignore_path, format!("{}\n", ignore_line)).unwrap();
-        watch!(gitignore_path.exists());
 
         let gitignore = build_ignore_patterns("", &git_root, ".gitignore").unwrap();
-
-        watch!(gitignore);
 
         gitignore.check(&path)
     }

--- a/core/src/util/git.rs
+++ b/core/src/util/git.rs
@@ -87,7 +87,14 @@ pub fn exec_git(git_command: &str, xvc_directory: &str, args_str_vec: &[&str]) -
 /// NOTE: Assumptions for this function:
 /// - No submodules
 pub fn get_git_tracked_files(git_command: &str, xvc_directory: &str) -> Result<Vec<String>> {
-    let git_ls_files_out = exec_git(git_command, xvc_directory, &["ls-files", "--full-name"])?;
+    let git_ls_files_out = exec_git(
+        git_command,
+        xvc_directory,
+        // XXX: When core.quotepath is in its default value, all UTF-8 paths are converted to octal
+        // strings and we lose the ability to match them. We supply a one off config value to set
+        // it to off.
+        &["-c", "core.quotepath=off", "ls-files", "--full-name"],
+    )?;
     watch!(git_ls_files_out);
     let git_ls_files_out = git_ls_files_out
         .lines()

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -38,11 +38,8 @@ pub fn stdin_channel() -> Receiver<String> {
                     break;
                 }
                 let mut input = stdin.lock();
-                watch!(&input);
                 let mut buf = Vec::<u8>::new();
-                watch!(&buf);
                 let read_bytes = input.read(&mut buf)?;
-                watch!(&buf);
                 if read_bytes > 0 {
                     let s = String::from_utf8(buf);
                     input_snd
@@ -51,11 +48,8 @@ pub fn stdin_channel() -> Receiver<String> {
                 }
                 drop(input);
                 sleep(Duration::from_millis(10));
-
-                watch!("Input looping");
             }
 
-            watch!("Exit input loop");
             Ok(())
         });
     })

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -12,7 +12,6 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use crossbeam_channel::{bounded, Receiver};
-use xvc_logging::watch;
 
 use crate::error::Result;
 use crate::{XvcMetadata, XvcPath, CHANNEL_BOUND};

--- a/core/src/util/xvcignore.rs
+++ b/core/src/util/xvcignore.rs
@@ -8,7 +8,7 @@ use crossbeam_channel::{bounded, Sender};
 
 use std::sync::{Arc, RwLock};
 use std::thread;
-use xvc_logging::{warn, watch, XvcOutputSender};
+use xvc_logging::{warn, XvcOutputSender};
 use xvc_walker::{self, IgnoreRules, PathMetadata, WalkOptions};
 use xvc_walker::{Result as XvcWalkerResult, SharedIgnoreRules};
 

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -339,15 +339,14 @@ impl<T> HStore<T> {
     }
 
     /// returns a subset of the store defined by iterator of XvcEntity
-    pub fn subset<I>(&self, keys: I) -> Result<HStore<T>>
+    pub fn subset<I>(&self, keys: &[XvcEntity]) -> Result<HStore<T>>
     where
-        I: Iterator<Item = XvcEntity>,
         T: Clone,
     {
         let mut map = HashMap::<XvcEntity, T>::with_capacity(self.len());
         for e in keys {
-            if let Some(v) = self.get(&e) {
-                map.insert(e, v.clone());
+            if let Some(v) = self.get(e) {
+                map.insert(*e, v.clone());
             } else {
                 Error::CannotFindKeyInStore { key: e.to_string() }.warn();
             }

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -339,14 +339,15 @@ impl<T> HStore<T> {
     }
 
     /// returns a subset of the store defined by iterator of XvcEntity
-    pub fn subset<I>(&self, keys: &[XvcEntity]) -> Result<HStore<T>>
+    pub fn subset<I>(&self, keys: I) -> Result<HStore<T>>
     where
+        I: Iterator<Item = XvcEntity>,
         T: Clone,
     {
         let mut map = HashMap::<XvcEntity, T>::with_capacity(self.len());
         for e in keys {
-            if let Some(v) = self.get(e) {
-                map.insert(*e, v.clone());
+            if let Some(v) = self.get(&e) {
+                map.insert(e, v.clone());
             } else {
                 Error::CannotFindKeyInStore { key: e.to_string() }.warn();
             }

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -267,23 +267,33 @@ impl<T> HStore<T> {
     /// The returned store contains `(Option<T>, Option<U>)` values that correspond to the
     /// identical `XvcEntity` values.
     ///
-    /// ## Example
-    ///
-    /// If this store has
-    ///
-    /// `{10: "John Doe", 12: "George Mason", 19: "Ali Canfield"}`,
-    /// and the `other` store contains
-    /// `{10: "Carpenter", 17: "Developer", 15: "Plumber",  19: "Artist" }`
-    ///
-    /// `full_join` will return
-    ///
-    /// `{10: (Some("John Doe"), Some("Carpenter")),
-    ///   12: (Some("George Mason"), None),
-    ///   15: (None, Some("Plumber"))
-    ///   19: (Some("Ali Canfield"), Some("Artist")}`
-    ///
     /// Note that, it may be more convenient to keep this relationship in a [crate::R11Store]
     /// if your stores don't use filtering
+    ///
+    /// ```rust
+    ///
+    /// use xvc_ecs::{XvcEntity, HStore};
+    ///
+    /// let mut store1 = HStore::<String>::new();
+    /// store1.insert(10u128.into(), "John Doe".into());
+    /// store1.insert(12u128.into(), "George Mason".into());
+    /// store1.insert(19u128.into(), "Ali Canfield".into());
+    ///
+    /// let mut store2 = HStore::<String>::new();
+    /// store2.insert(10u128.into(), "Carpenter".into());
+    /// store2.insert(17u128.into(), "Developer".into());
+    /// store2.insert(15u128.into(), "Plumber".into());
+    /// store2.insert(19u128.into(), "Artist".into());
+    ///
+    /// let result = store1.full_join(store2);
+    ///
+    /// assert_eq!(result.len(), 5);
+    /// assert_eq!(result[&10u128.into()], (Some("John Doe".into()), Some("Carpenter".into())));
+    /// assert_eq!(result[&12u128.into()], (Some("George Mason".into()), None));
+    /// assert_eq!(result[&15u128.into()], (None, Some("Plumber".into())));
+    /// assert_eq!(result[&17u128.into()], (None, Some("Developer".into())));
+    /// assert_eq!(result[&19u128.into()], (Some("Ali Canfield".into()), Some("Artist".into())));
+    ///
     pub fn full_join<U>(&self, other: HStore<U>) -> HStore<(Option<T>, Option<U>)>
     where
         T: Storable,
@@ -321,6 +331,26 @@ impl<T> HStore<T> {
     ///
     /// Note that, it may be more convenient to keep this relationship in a [crate::R11Store]
     /// if your stores don't use filtering
+    /// ```rust
+    ///
+    /// use xvc_ecs::{XvcEntity, HStore};
+    ///
+    /// let mut store1 = HStore::<String>::new();
+    /// store1.insert(10u128.into(), "John Doe".into());
+    /// store1.insert(12u128.into(), "George Mason".into());
+    /// store1.insert(19u128.into(), "Ali Canfield".into());
+    ///
+    /// let mut store2 = HStore::<String>::new();
+    /// store2.insert(10u128.into(), "Carpenter".into());
+    /// store2.insert(17u128.into(), "Developer".into());
+    /// store2.insert(15u128.into(), "Plumber".into());
+    /// store2.insert(19u128.into(), "Artist".into());
+    ///
+    /// let result = store1.join(store2);
+    ///
+    /// assert_eq!(result.len(), 2);
+    /// assert_eq!(result[&10u128.into()], ("John Doe".into(), "Carpenter".into()));
+    /// assert_eq!(result[&19u128.into()], ("Ali Canfield".into(), "Artist".into()));
     pub fn join<U>(&self, other: HStore<U>) -> HStore<(T, U)>
     where
         T: Storable,

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -293,7 +293,7 @@ impl<T> HStore<T> {
     /// assert_eq!(result[&15u128.into()], (None, Some("Plumber".into())));
     /// assert_eq!(result[&17u128.into()], (None, Some("Developer".into())));
     /// assert_eq!(result[&19u128.into()], (Some("Ali Canfield".into()), Some("Artist".into())));
-    ///
+    /// ```
     pub fn full_join<U>(&self, other: HStore<U>) -> HStore<(Option<T>, Option<U>)>
     where
         T: Storable,

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -102,7 +102,6 @@ where
     {
         let mut hstore = HStore::<T>::new();
         for value in values {
-            watch!(value);
             let key = match store.entity_by_value(&value) {
                 Some(e) => e,
                 None => gen.next_element(),

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -106,7 +106,6 @@ where
                 Some(e) => e,
                 None => gen.next_element(),
             };
-            watch!(key);
             hstore.map.insert(key, value.clone());
         }
         hstore

--- a/ecs/src/ecs/mod.rs
+++ b/ecs/src/ecs/mod.rs
@@ -27,7 +27,6 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use serde::{Deserialize, Serialize};
-use xvc_logging::watch;
 
 use crate::error::{Error as XvcError, Result};
 

--- a/ecs/src/ecs/mod.rs
+++ b/ecs/src/ecs/mod.rs
@@ -226,7 +226,6 @@ pub fn sorted_files(dir: &Path) -> Result<Vec<PathBuf>> {
 /// It gets files with [sorted_files] and returns the last one if there is one.
 /// If there are no files in a directory, this returns `Ok(None)`.
 pub fn most_recent_file(dir: &Path) -> Result<Option<PathBuf>> {
-    watch!(dir);
     if !dir.exists() {
         return Ok(None);
     }
@@ -236,7 +235,6 @@ pub fn most_recent_file(dir: &Path) -> Result<Option<PathBuf>> {
     if files.is_empty() {
         Ok(None)
     } else {
-        watch!(files);
         Ok(files.last().cloned())
     }
 }

--- a/ecs/src/ecs/r11store.rs
+++ b/ecs/src/ecs/r11store.rs
@@ -35,7 +35,6 @@ where
     /// use xvc_ecs::R11Store;
     /// let rs = R11Store::<String, i32>::new();
     /// ```
-
     pub fn new() -> Self {
         Self {
             left: XvcStore::<T>::new(),

--- a/ecs/src/ecs/r11store.rs
+++ b/ecs/src/ecs/r11store.rs
@@ -67,7 +67,6 @@ where
     /// let entity: XvcEntity = (100u64, 200u64).into();
     /// rs.insert(&entity, "left component".into(), "right component".to_string());
     /// ```
-
     pub fn left_to_right(&self, entity: &XvcEntity) -> Option<(&XvcEntity, &U)> {
         self.right.get_key_value(entity)
     }
@@ -92,7 +91,6 @@ where
     /// rs.insert(&entity, "left component".into(), "right component".into());
     /// let t = rs.tuple(&entity);
     /// ```
-
     pub fn tuple(&self, entity: &XvcEntity) -> (Option<&T>, Option<&U>) {
         (self.left.get(entity), self.right.get(entity))
     }
@@ -141,6 +139,19 @@ where
             None => None,
             Some(xe) => self.left.get(&xe),
         }
+    }
+
+    /// Run a filter on the store and return elements selected by the predicate
+    pub fn filter(&self, predicate: impl Fn(&T, &U) -> bool) -> R11Store<T, U> {
+        let mut rs = R11Store::<T, U>::new();
+        for (entity, left) in self.left.iter() {
+            if let Some(right) = self.right.get(entity) {
+                if predicate(left, right) {
+                    rs.insert(entity, left.clone(), right.clone());
+                }
+            }
+        }
+        rs
     }
 }
 

--- a/ecs/src/ecs/xvcstore.rs
+++ b/ecs/src/ecs/xvcstore.rs
@@ -355,10 +355,10 @@ where
     ///
     /// let result = store1.left_join(store2);
     ///
-    /// assert_eq!(result.len(), 5);
-    /// assert_eq!(result[&10u128.into()], "John Doe".into(), Some("Carpenter".into()));
-    /// assert_eq!(result[&12u128.into()], "George Mason".into(), None);
-    /// assert_eq!(result[&19u128.into()], "Ali Canfield".into(), Some("Artist".into()));
+    /// assert_eq!(result.len(), 3);
+    /// assert_eq!(result[&10u128.into()], ("John Doe".into(), Some("Carpenter".into())));
+    /// assert_eq!(result[&12u128.into()], ("George Mason".into(), None));
+    /// assert_eq!(result[&19u128.into()], ("Ali Canfield".into(), Some("Artist".into())));
     ///
     /// ```
     ///

--- a/ecs/src/ecs/xvcstore.rs
+++ b/ecs/src/ecs/xvcstore.rs
@@ -334,23 +334,32 @@ where
     /// The returned store contains `(T, Option<U>)` values that correspond to the identical
     /// `XvcEntity` values.
     ///
-    /// ## Example
-    ///
-    /// If this store has
-    ///
-    /// `{10: "John Doe", 12: "George Mason", 19: "Ali Canfield"}`,
-    /// and the `other` store contains
-    /// `{10: "Carpenter", 17: "Developer", 19: "Artist" }`
-    ///
-    /// `join` will return
-    ///
-    /// `{10: ("John Doe", Some("Carpenter")), 12: ("George Mason", None), 19: ("Ali Canfield",
-    /// Some("Artist")}`
-    ///
     /// In SQL terms, this is a LEFT JOIN.
     ///
-    /// Note that, it may be more convenient to keep this relationship in a [crate::R11Store]
-    /// relative to your use case.
+    /// Note that, it may be more convenient to keep this relationship in a [crate::R11Store] relative to your use case.
+    ///
+    /// ```rust
+    ///
+    /// use xvc_ecs::{XvcEntity, XvcStore};
+    ///
+    /// let mut store1 = XvcStore::<String>::new();
+    /// store1.insert(10u128.into(), "John Doe".into());
+    /// store1.insert(12u128.into(), "George Mason".into());
+    /// store1.insert(19u128.into(), "Ali Canfield".into());
+    ///
+    /// let mut store2 = XvcStore::<String>::new();
+    /// store2.insert(10u128.into(), "Carpenter".into());
+    /// store2.insert(17u128.into(), "Developer".into());
+    /// store2.insert(15u128.into(), "Plumber".into());
+    /// store2.insert(19u128.into(), "Artist".into());
+    ///
+    /// let result = store1.left_join(store2);
+    ///
+    /// assert_eq!(result.len(), 5);
+    /// assert_eq!(result[&10u128.into()], "John Doe".into(), Some("Carpenter".into())));
+    /// assert_eq!(result[&12u128.into()], "George Mason".into(), None));
+    /// assert_eq!(result[&19u128.into()], "Ali Canfield".into(), Some("Artist".into())));
+    /// ```
     pub fn left_join<U>(&self, other: XvcStore<U>) -> XvcStore<(T, Option<U>)>
     where
         U: Storable,

--- a/ecs/src/ecs/xvcstore.rs
+++ b/ecs/src/ecs/xvcstore.rs
@@ -329,7 +329,7 @@ where
         &self.current
     }
 
-    /// Performs a join with [XvcEntity] keys.
+    /// Performs a left join with [XvcEntity] keys.
     ///
     /// The returned store contains `(T, Option<U>)` values that correspond to the identical
     /// `XvcEntity` values.
@@ -351,7 +351,7 @@ where
     ///
     /// Note that, it may be more convenient to keep this relationship in a [crate::R11Store]
     /// relative to your use case.
-    pub fn join<U>(&self, other: XvcStore<U>) -> XvcStore<(T, Option<U>)>
+    pub fn left_join<U>(&self, other: XvcStore<U>) -> XvcStore<(T, Option<U>)>
     where
         U: Storable,
     {

--- a/ecs/src/ecs/xvcstore.rs
+++ b/ecs/src/ecs/xvcstore.rs
@@ -356,10 +356,13 @@ where
     /// let result = store1.left_join(store2);
     ///
     /// assert_eq!(result.len(), 5);
-    /// assert_eq!(result[&10u128.into()], "John Doe".into(), Some("Carpenter".into())));
-    /// assert_eq!(result[&12u128.into()], "George Mason".into(), None));
-    /// assert_eq!(result[&19u128.into()], "Ali Canfield".into(), Some("Artist".into())));
+    /// assert_eq!(result[&10u128.into()], "John Doe".into(), Some("Carpenter".into()));
+    /// assert_eq!(result[&12u128.into()], "George Mason".into(), None);
+    /// assert_eq!(result[&19u128.into()], "Ali Canfield".into(), Some("Artist".into()));
+    ///
     /// ```
+    ///
+    ///
     pub fn left_join<U>(&self, other: XvcStore<U>) -> XvcStore<(T, Option<U>)>
     where
         U: Storable,

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -21,12 +21,12 @@ test = true
 bench = true
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.3", path = "../storage", default-features = false }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.4", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -102,5 +102,5 @@ default = ["reflink"]
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
 shellfn = "^0.1"

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -21,12 +21,12 @@ test = true
 bench = true
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.2", path = "../storage", default-features = false }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.3", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -95,5 +95,5 @@ default = ["reflink"]
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
 shellfn = "^0.1"

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -21,12 +21,12 @@ test = true
 bench = true
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.4", path = "../storage", default-features = false }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.5", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.5", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.5", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.5", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -102,5 +102,5 @@ default = []
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.5", path = "../test_helper/" }
 shellfn = "^0.1"

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -87,7 +87,14 @@ uuid = { version = "^1.10", features = ["serde", "v4", "fast-rng"] }
 hex = { version = "^0.4", features = ["serde"] }
 url = { version = "^2.5", features = ["serde"] }
 itertools = "^0.13"
-derive_more = { version = "^1.0", features = ["full"] }
+# FIXME: These are mostly used in file/src/common/mod.rs and TextOrBinary wrapper. 
+derive_more = { version = "^1.0", features = [
+  "from",
+  "display",
+  "as_ref",
+  "deref",
+  "from_str",
+] }
 parse-size = "^1.1"
 
 [features]

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -98,7 +98,7 @@ derive_more = { version = "^1.0", features = [
 parse-size = "^1.1"
 
 [features]
-default = ["reflink"]
+default = []
 reflink = ["dep:reflink"]
 
 [dev-dependencies]

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -21,12 +21,12 @@ test = true
 bench = true
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.1", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.1", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.1", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.1", path = "../storage", default-features = false }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.2", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -95,5 +95,5 @@ default = ["reflink"]
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.1", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
 shellfn = "^0.1"

--- a/file/src/bring/mod.rs
+++ b/file/src/bring/mod.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 
 use xvc_core::{ContentDigest, RecheckMethod, XvcCachePath, XvcFileType, XvcMetadata, XvcRoot};
 use xvc_ecs::{HStore, XvcStore};
-use xvc_logging::{debug, error, uwr, warn, watch, XvcOutputSender};
+use xvc_logging::{debug, error, uwr, warn, XvcOutputSender};
 
 use xvc_storage::XvcStorageEvent;
 use xvc_storage::{storage::get_storage_record, StorageIdentifier, XvcStorageOperations};

--- a/file/src/bring/mod.rs
+++ b/file/src/bring/mod.rs
@@ -67,7 +67,6 @@ pub fn fetch(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: &BringCLI) 
     let current_dir = xvc_root.config().current_dir()?;
     let targets = load_targets_from_store(output_snd, xvc_root, current_dir, &opts.targets)?;
     let force = opts.force;
-    watch!(targets);
 
     let target_xvc_metadata = xvc_root
         .load_store::<XvcMetadata>()?
@@ -82,7 +81,6 @@ pub fn fetch(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: &BringCLI) 
     let content_digest_store: XvcStore<ContentDigest> = xvc_root.load_store()?;
 
     let target_content_digests = content_digest_store.subset(target_files.keys().copied())?;
-    watch!(target_content_digests);
 
     assert! {
         target_content_digests.len() == target_files.len(),
@@ -115,8 +113,6 @@ pub fn fetch(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: &BringCLI) 
         })
         .collect();
 
-    watch!(cache_paths);
-
     let (temp_dir, event) = storage
         .receive(
             output_snd,
@@ -129,9 +125,6 @@ pub fn fetch(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: &BringCLI) 
             opts.force,
         )
         .map_err(|e| xvc_core::Error::from(anyhow::anyhow!("Remote error: {}", e)))?;
-
-    watch!(temp_dir);
-    watch!(event);
 
     let path_sync = PathSync::new();
     // Move the files from temp dir to cache
@@ -165,10 +158,8 @@ pub fn fetch(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: &BringCLI) 
 /// - [checkout][cmd_checkout] them from storage if `opts.no_checkout` is false. (default)
 pub fn cmd_bring(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: BringCLI) -> Result<()> {
     fetch(output_snd, xvc_root, &opts)?;
-    watch!("Fetch completed");
     if !opts.no_recheck {
         let recheck_targets = opts.targets.clone();
-        watch!(recheck_targets);
 
         let recheck_opts = RecheckCLI {
             recheck_method: opts.recheck_as,

--- a/file/src/carry_in/mod.rs
+++ b/file/src/carry_in/mod.rs
@@ -100,8 +100,6 @@ impl UpdateFromXvcConfig for CarryInCLI {
 ///     XvcDigest --> CacheLocation
 ///
 /// ```
-///
-
 pub fn cmd_carry_in(
     output_snd: &XvcOutputSender,
     xvc_root: &XvcRoot,

--- a/file/src/carry_in/mod.rs
+++ b/file/src/carry_in/mod.rs
@@ -105,14 +105,10 @@ pub fn cmd_carry_in(
     xvc_root: &XvcRoot,
     cli_opts: CarryInCLI,
 ) -> Result<()> {
-    watch!(cli_opts);
-    watch!(xvc_root);
     let conf = xvc_root.config();
     let opts = cli_opts.update_from_conf(conf)?;
-    watch!(opts);
     let current_dir = conf.current_dir()?;
     let targets = load_targets_from_store(output_snd, xvc_root, current_dir, &opts.targets)?;
-    watch!(targets);
 
     let stored_xvc_path_store = xvc_root.load_store::<XvcPath>()?;
     let stored_xvc_metadata_store = xvc_root.load_store::<XvcMetadata>()?;
@@ -150,8 +146,6 @@ pub fn cmd_carry_in(
         None,
         !opts.no_parallel,
     );
-
-    watch!(content_digest_diff);
 
     let xvc_paths_to_carry = if opts.force {
         target_files
@@ -196,7 +190,6 @@ pub fn cmd_carry_in(
         .collect();
 
     let stored_recheck_method_store = xvc_root.load_store::<RecheckMethod>()?;
-    watch!(xvc_paths_to_carry);
     carry_in(
         output_snd,
         xvc_root,
@@ -236,21 +229,14 @@ pub fn carry_in(
 
     let path_sync = PathSync::new();
 
-    watch!(ignore_writer);
-    watch!(ignore_thread);
-
     let copy_path_to_cache_and_recheck = |xe, xp| {
         let cache_path = uwo!(cache_paths.get(xe).cloned(), output_snd);
-        watch!(cache_path);
         let abs_cache_path = cache_path.to_absolute_path(xvc_root);
-        watch!(abs_cache_path);
         if abs_cache_path.exists() {
             if force {
                 let cache_dir = uwo!(abs_cache_path.parent(), output_snd);
                 uwr!(set_writable(cache_dir), output_snd);
-                watch!(cache_dir.metadata().unwrap().permissions());
                 uwr!(set_writable(&abs_cache_path), output_snd);
-                watch!(abs_cache_path.metadata().unwrap().permissions());
                 /* let mut dir_perm = cache_dir.metadata()?.permissions(); */
                 /* dir_perm.set_readonly(true); */
                 uwr!(fs::remove_file(&abs_cache_path), output_snd);
@@ -264,8 +250,6 @@ pub fn carry_in(
                 info!(output_snd, "[EXISTS] {abs_cache_path} for {xp}");
             }
         } else {
-            watch!(&cache_path);
-            watch!(&xp);
             uwr!(
                 move_xvc_path_to_cache(xvc_root, xp, &cache_path, &path_sync),
                 output_snd
@@ -273,7 +257,6 @@ pub fn carry_in(
             info!(output_snd, "[CARRY] {xp} -> {cache_path}");
         }
         let target_path = xp.to_absolute_path(xvc_root);
-        watch!(target_path);
         if target_path.exists() {
             uwr!(fs::remove_file(&target_path), output_snd);
             info!(output_snd, "[REMOVE] {target_path}");
@@ -290,9 +273,6 @@ pub fn carry_in(
             ),
             output_snd
         );
-        watch!(&cache_path);
-        watch!(recheck_method);
-        watch!(&xp);
         info!(output_snd, "[RECHECK] {cache_path} -> {xp}");
     };
 

--- a/file/src/common/compare.rs
+++ b/file/src/common/compare.rs
@@ -21,7 +21,7 @@ use xvc_core::{
 };
 
 use xvc_ecs::{HStore, XvcEntity, XvcStore};
-use xvc_logging::{debug, error, panic, watch, XvcOutputSender};
+use xvc_logging::{debug, error, panic, XvcOutputSender};
 
 use super::FileTextOrBinary;
 
@@ -198,8 +198,7 @@ pub fn diff_file_content_digest(
             Diff::RecordMissing { actual } => {
                 let path = actual.to_absolute_path(xvc_root);
                 let actual_digest = ContentDigest::new(&path, algorithm, text_or_binary.0)?;
-                let res = compare_with_stored_digest(actual_digest);
-                res
+                compare_with_stored_digest(actual_digest)
             }
             // The path is changed. This can happen after a move
             // operation, for example.

--- a/file/src/common/compare.rs
+++ b/file/src/common/compare.rs
@@ -35,7 +35,6 @@ pub fn diff_xvc_path_metadata(
     stored_xvc_metadata_store: &XvcStore<XvcMetadata>,
     pmm: &XvcPathMetadataMap,
 ) -> DiffStore2<XvcPath, XvcMetadata> {
-    watch!(pmm);
     let actual_xvc_path_store: HStore<XvcPath> = HStore::from_storable(
         pmm.keys().cloned(),
         stored_xvc_path_store,
@@ -142,8 +141,6 @@ pub fn diff_file_content_digest(
             Ok(path)
         };
         let compare_with_stored_digest = |actual| -> Diff<ContentDigest> {
-            watch!(stored_content_digest);
-            watch!(actual);
             match stored_content_digest {
                 Some(record) => {
                     if actual != *record {
@@ -159,7 +156,6 @@ pub fn diff_file_content_digest(
             }
         };
 
-        watch!(xvc_path_diff);
         let diff_content_digest = match xvc_path_diff {
             Diff::Identical | Diff::Skipped => {
                 match xvc_metadata_diff {
@@ -200,13 +196,9 @@ pub fn diff_file_content_digest(
             }
             // The path is not recorded before.
             Diff::RecordMissing { actual } => {
-                watch!(actual);
                 let path = actual.to_absolute_path(xvc_root);
-                watch!(path);
                 let actual_digest = ContentDigest::new(&path, algorithm, text_or_binary.0)?;
-                watch!(actual_digest);
                 let res = compare_with_stored_digest(actual_digest);
-                watch!(res);
                 res
             }
             // The path is changed. This can happen after a move
@@ -466,8 +458,6 @@ pub fn diff_content_digest(
         .copied()
         .collect::<HashSet<XvcEntity>>();
 
-    watch!(file_entities);
-
     let dir_entities = entities
         .iter()
         .filter(|xe| {
@@ -477,7 +467,6 @@ pub fn diff_content_digest(
         })
         .copied()
         .collect::<HashSet<XvcEntity>>();
-    watch!(dir_entities);
 
     entities
         .difference(&file_entities)
@@ -555,7 +544,6 @@ pub fn diff_content_digest(
         )
     };
 
-    watch!(file_content_digest_diff_store.keys());
     let mut diff_store = DiffStore::with_capacity(
         file_content_digest_diff_store.len() + dir_content_digest_diff_store.len(),
     );

--- a/file/src/common/mod.rs
+++ b/file/src/common/mod.rs
@@ -221,7 +221,6 @@ pub fn filter_paths_by_globs(
 ///
 /// This function will return an error if any of the glob patterns are invalid.
 ///
-
 pub fn build_glob_matcher(
     output_snd: &XvcOutputSender,
     dir: &Path,

--- a/file/src/common/mod.rs
+++ b/file/src/common/mod.rs
@@ -29,7 +29,7 @@ use xvc_core::{
 };
 use xvc_core::{get_absolute_git_command, get_git_tracked_files, HashAlgorithm};
 use xvc_ecs::ecs::event::EventLog;
-use xvc_logging::{error, info, uwr, warn, watch, XvcOutputSender};
+use xvc_logging::{error, info, uwr, warn, XvcOutputSender};
 
 use xvc_ecs::{persist, HStore, Storable, XvcStore};
 
@@ -253,7 +253,6 @@ pub fn build_glob_matcher(
 /// If some day we need to optimize first walking the ignores, then walking the
 /// directories in the targets, I'd be glad that this is used in very large
 /// repositories.
-
 pub fn targets_from_disk(
     output_snd: &XvcOutputSender,
     xvc_root: &XvcRoot,

--- a/file/src/common/mod.rs
+++ b/file/src/common/mod.rs
@@ -140,12 +140,9 @@ pub fn filter_targets_from_store(
         );
     }
 
-    watch!(targets);
-
     if let Some(targets) = targets {
         let paths =
             filter_paths_by_globs(output_snd, xvc_root, xvc_path_store, targets.as_slice())?;
-        watch!(paths);
         Ok(paths)
     } else {
         Ok(xvc_path_store.into())
@@ -162,7 +159,6 @@ pub fn filter_paths_by_globs(
     paths: &XvcStore<XvcPath>,
     globs: &[String],
 ) -> Result<HStore<XvcPath>> {
-    watch!(globs);
     if globs.is_empty() {
         return Ok(paths.into());
     }
@@ -171,10 +167,8 @@ pub fn filter_paths_by_globs(
     let globs = globs
         .iter()
         .map(|g| {
-            watch!(g);
             if !g.ends_with('/') && !g.contains('*') {
                 let slashed = format!("{g}/");
-                watch!(slashed);
                 // We don't track directories. Instead we look for files that start with the directory.
                 if paths.any(|_, p| p.as_str().starts_with(&slashed)) {
                     slashed
@@ -187,9 +181,7 @@ pub fn filter_paths_by_globs(
         })
         .collect::<Vec<String>>();
 
-    watch!(globs);
     let mut glob_matcher = build_glob_matcher(output_snd, xvc_root, &globs)?;
-    watch!(glob_matcher);
     let paths = paths
         .iter()
         .filter_map(|(e, p)| {
@@ -201,7 +193,6 @@ pub fn filter_paths_by_globs(
         })
         .collect();
 
-    watch!(paths);
     Ok(paths)
 }
 
@@ -228,14 +219,12 @@ pub fn build_glob_matcher(
 ) -> Result<Glob> {
     let mut glob_matcher = Glob::default();
     globs.iter().for_each(|t| {
-        watch!(t);
         if t.ends_with('/') {
             if !glob_matcher.add(&format!("{t}**")) {
                 error!(output_snd, "Error in glob: {t}");
             }
         } else if !t.contains('*') {
             let abs_target = dir.join(Path::new(t));
-            watch!(abs_target);
             if abs_target.is_dir() {
                 if !glob_matcher.add(&format!("{t}/**")) {
                     error!(output_snd, "Error in glob: {t}")
@@ -272,8 +261,6 @@ pub fn targets_from_disk(
     targets: &Option<Vec<String>>,
     filter_git_paths: bool,
 ) -> Result<XvcPathMetadataMap> {
-    watch!(current_dir);
-    watch!(xvc_root.absolute_path());
     // If we are not in the root, we add current dir to all targets and recur.
     if *current_dir != *xvc_root.absolute_path() {
         let cwd = current_dir
@@ -291,7 +278,6 @@ pub fn targets_from_disk(
             Some(targets) => targets.iter().map(|t| format!("{cwd}{t}")).collect(),
             None => vec![cwd.to_string()],
         };
-        watch!(targets);
         return targets_from_disk(
             output_snd,
             xvc_root,
@@ -342,7 +328,6 @@ pub fn targets_from_disk(
         xpmm
     };
 
-    watch!(all_paths);
     // Return false when the path is a git path
 
     let git_files: HashSet<String> = if filter_git_paths {
@@ -387,7 +372,6 @@ pub fn targets_from_disk(
         }
 
         let mut glob_matcher = build_glob_matcher(output_snd, xvc_root, targets)?;
-        watch!(glob_matcher);
         Ok(all_paths
             .into_iter()
             .filter(|(p, _)| git_path_filter(p))
@@ -452,11 +436,8 @@ pub fn recheck_from_cache(
     ignore_writer: &Sender<IgnoreOp>,
 ) -> Result<()> {
     if let Some(parent) = xvc_path.parents().first() {
-        watch!(parent);
         let parent_dir = parent.to_absolute_path(xvc_root);
-        watch!(parent_dir);
         if !parent_dir.exists() {
-            watch!(&parent_dir);
             fs::create_dir_all(parent_dir)?;
             uwr!(
                 ignore_writer.send(Some(IgnoreOperation::IgnoreDir {
@@ -467,17 +448,11 @@ pub fn recheck_from_cache(
         }
     }
     let cache_path = cache_path.to_absolute_path(xvc_root);
-    watch!(cache_path);
     let path = xvc_path.to_absolute_path(xvc_root);
-    watch!(path);
     // If the file already exists, we delete it.
     if path.exists() {
-        watch!("exists!");
         fs::remove_file(&path)?;
     }
-
-    watch!(path);
-    watch!(recheck_method);
 
     match recheck_method {
         RecheckMethod::Copy => {
@@ -501,7 +476,6 @@ pub fn recheck_from_cache(
         })),
         output_snd
     );
-    watch!("Return recheck_from_cache");
     Ok(())
 }
 
@@ -540,9 +514,7 @@ fn copy_file(
 #[cfg(not(unix))]
 pub fn set_writable(path: &Path) -> Result<()> {
     let mut perm = path.metadata()?.permissions();
-    watch!(&perm);
     perm.set_readonly(false);
-    watch!(&perm);
     fs::set_permissions(path, perm)?;
     Ok(())
 }
@@ -550,9 +522,7 @@ pub fn set_writable(path: &Path) -> Result<()> {
 #[cfg(not(unix))]
 pub fn set_readonly(path: &Path) -> Result<()> {
     let mut perm = path.metadata()?.permissions();
-    watch!(&perm);
     perm.set_readonly(true);
-    watch!(&perm);
     fs::set_permissions(path, perm)?;
     Ok(())
 }
@@ -654,7 +624,6 @@ pub fn move_to_cache(
     let cache_dir = cache_path.parent().ok_or(Error::InternalError {
         message: "Cache path has no parent.".to_string(),
     })?;
-    watch!(cache_dir);
     // We don't lock the path_sync here because we don't want to block other threads.
     path_sync
         .with_sync_abs_path(path, |path| {
@@ -670,10 +639,8 @@ pub fn move_to_cache(
                 fs::rename(path, cache_path)
                     .map_err(|source| xvc_walker::Error::IoError { source })?;
                 let mut file_perm = cache_path.metadata()?.permissions();
-                watch!(&file_perm.clone());
                 file_perm.set_readonly(true);
                 fs::set_permissions(cache_path, file_perm.clone())?;
-                watch!(&file_perm.clone());
                 let mut dir_perm = cache_dir.metadata()?.permissions();
                 dir_perm.set_readonly(true);
                 fs::set_permissions(cache_dir, dir_perm)?;
@@ -692,9 +659,7 @@ pub fn move_xvc_path_to_cache(
     path_sync: &PathSync,
 ) -> Result<()> {
     let path = xvc_path.to_absolute_path(xvc_root);
-    watch!(path);
     let cache_path = cache_path.to_absolute_path(xvc_root);
-    watch!(cache_path);
     move_to_cache(&path, &cache_path, path_sync)
 }
 
@@ -711,9 +676,7 @@ where
     T: Storable,
 {
     let records = xvc_root.load_store::<T>()?;
-    watch!(records.len());
     let new_store = apply_diff(&records, diffs, add_new, remove_missing)?;
-    watch!(new_store.len());
     xvc_root.save_store(&new_store)?;
     Ok(())
 }

--- a/file/src/copy/mod.rs
+++ b/file/src/copy/mod.rs
@@ -289,7 +289,6 @@ pub(crate) fn recheck_destination(
     xvc_root: &XvcRoot,
     destination_entities: &[XvcEntity],
 ) -> Result<()> {
-    watch!(destination_entities);
     let (ignore_writer, ignore_thread) = make_ignore_handler(output_snd, xvc_root)?;
     let (recheck_handler, recheck_thread) =
         make_recheck_handler(output_snd, xvc_root, &ignore_writer)?;
@@ -337,9 +336,6 @@ pub fn cmd_copy(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: CopyCLI)
         &opts.destination,
     )?;
 
-    watch!(source_xvc_paths);
-    watch!(source_metadata);
-
     let source_dest_store = get_copy_source_dest_store(
         output_snd,
         xvc_root,
@@ -351,8 +347,6 @@ pub fn cmd_copy(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: CopyCLI)
         opts.name_only,
         opts.force,
     )?;
-
-    watch!(source_dest_store);
 
     xvc_root.with_r11store_mut(|store: &mut R11Store<XvcPath, XvcMetadata>| {
         for (source_xe, (dest_xe, dest_path)) in source_dest_store.iter() {

--- a/file/src/copy/mod.rs
+++ b/file/src/copy/mod.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 
 use xvc_core::{ContentDigest, Diff, RecheckMethod, XvcFileType, XvcMetadata, XvcPath, XvcRoot};
 use xvc_ecs::{HStore, R11Store, XvcEntity, XvcStore};
-use xvc_logging::{debug, error, watch, XvcOutputSender};
+use xvc_logging::{debug, error, XvcOutputSender};
 
 /// CLI for `xvc file copy`.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]

--- a/file/src/hash/mod.rs
+++ b/file/src/hash/mod.rs
@@ -13,7 +13,7 @@ use xvc_core::{
     util::file::{path_metadata_channel, pipe_filter_path_errors},
     HashAlgorithm, TextOrBinary, XvcRoot,
 };
-use xvc_logging::{output, watch, XvcOutputSender};
+use xvc_logging::{output, XvcOutputSender};
 use xvc_walker::AbsolutePath;
 
 use crate::common::pipe_path_digest;

--- a/file/src/hash/mod.rs
+++ b/file/src/hash/mod.rs
@@ -82,7 +82,6 @@ pub fn cmd_hash(
     let targets = opts.targets;
 
     for t in targets {
-        watch!(t);
         if !t.exists() {
             Error::FileNotFound { path: t }.error();
             continue;
@@ -96,8 +95,6 @@ pub fn cmd_hash(
             pipe_path_digest(filtered_path_rec, digest_snd, algorithm, text_or_binary)?;
 
             for (path, digest) in digest_rec {
-                watch!(path);
-                watch!(digest);
                 output!(output_snd, "{digest}\t{}", path.to_string_lossy());
             }
         } else if t.is_file() {

--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -170,7 +170,6 @@ pub fn run(
     xvc_root: Option<&XvcRoot>,
     opts: XvcFileCLI,
 ) -> Result<()> {
-    watch!(opts);
     match opts.subcommand {
         XvcFileSubCommand::Track(opts) => cmd_track(
             output_snd,

--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -52,7 +52,7 @@ use xvc_core::default_project_config;
 use xvc_core::types::xvcroot::load_xvc_root;
 use xvc_core::XvcRoot;
 use xvc_core::CHANNEL_BOUND;
-use xvc_logging::{setup_logging, watch};
+use xvc_logging::setup_logging;
 use xvc_logging::{XvcOutputLine, XvcOutputSender};
 use xvc_walker::AbsolutePath;
 

--- a/file/src/list/mod.rs
+++ b/file/src/list/mod.rs
@@ -240,14 +240,11 @@ impl ListRow {
             None => str::repeat(" ", DIGEST_LENGTH * 2),
         };
 
-        watch!(&path_prefix);
         let name = if let Some(ap) = path_match.actual_path {
-            watch!(ap);
             ap.strip_prefix(path_prefix.to_string_lossy().as_ref())
                 .map_err(|e| Error::RelativeStripPrefixError { e })?
                 .to_string()
         } else if let Some(rp) = path_match.recorded_path {
-            watch!(rp);
             rp.strip_prefix(path_prefix.to_string_lossy().as_ref())
                 .map_err(|e| Error::RelativeStripPrefixError { e })?
                 .to_string()
@@ -670,14 +667,10 @@ pub fn cmd_list_inner(
         &opts.targets,
         filter_git_paths,
     )?;
-    watch!(&all_from_disk);
 
     let from_disk = filter_xvc_path_metadata_map(all_from_disk, opts);
 
-    watch!(from_disk);
-
     let from_store = load_targets_from_store(output_snd, xvc_root, current_dir, &opts.targets)?;
-    watch!(from_store);
 
     let xvc_metadata_store = xvc_root.load_store::<XvcMetadata>()?;
 
@@ -695,7 +688,6 @@ pub fn cmd_list_inner(
         xvc_metadata_store,
         recheck_method_store,
     );
-    watch!(matches);
 
     let matches = if opts.format.as_ref().unwrap().columns.iter().any(|c| {
         *c == ListColumn::RecordedContentDigest64 || *c == ListColumn::RecordedContentDigest8
@@ -897,19 +889,12 @@ fn filter_xvc_path_metadata_map(
     all_from_disk: HashMap<XvcPath, XvcMetadata>,
     opts: &ListCLI,
 ) -> HashMap<XvcPath, XvcMetadata> {
-    watch!(opts.show_dot_files);
-    watch!(opts.show_directories);
     let filter_fn = match (opts.show_dot_files, opts.show_directories) {
         (true, true) => |_, _| true,
 
-        (true, false) => |_, md: &XvcMetadata| {
-            watch!(md);
-            !md.is_dir()
-        },
+        (true, false) => |_, md: &XvcMetadata| !md.is_dir(),
         (false, true) => |path: &XvcPath, _| !(path.starts_with_str(".") || path.contains("./")),
         (false, false) => |path: &XvcPath, md: &XvcMetadata| {
-            watch!(path);
-            watch!(md);
             !(path.starts_with_str(".") || path.contains("./") || md.is_dir())
         },
     };
@@ -918,7 +903,6 @@ fn filter_xvc_path_metadata_map(
         .iter()
         .filter_map(|(path, md)| {
             if filter_fn(path, md) {
-                watch!(path);
                 Some((path.clone(), *md))
             } else {
                 None
@@ -942,14 +926,11 @@ fn filter_xvc_path_xvc_metadata_stores(
         },
     };
 
-    watch!(filter_fn);
-
     xvc_path_store
         .iter()
         .filter_map(|(xvc_entity, xvc_path)| {
             if let Some(xvc_metadata) = xvc_metadata_store.get(xvc_entity) {
                 if filter_fn(xvc_path, xvc_metadata) {
-                    watch!(xvc_path);
                     Some(*xvc_entity)
                 } else {
                     None

--- a/file/src/list/mod.rs
+++ b/file/src/list/mod.rs
@@ -905,7 +905,7 @@ fn filter_dot_files(
     all_paths: HashMap<XvcPath, XvcMetadata>,
     show_dot_files: bool,
 ) -> HashMap<XvcPath, XvcMetadata> {
-    filter_paths(all_paths, show_dot_files, |path, _| {
+    filter_paths(all_paths, !show_dot_files, |path, _| {
         let path_str = path.to_string();
         !path_str.starts_with('.') && !path_str.contains("./")
     })
@@ -915,5 +915,5 @@ fn filter_directories(
     all_paths: HashMap<XvcPath, XvcMetadata>,
     show_directories: bool,
 ) -> HashMap<XvcPath, XvcMetadata> {
-    filter_paths(all_paths, show_directories, |_, md| !md.is_dir())
+    filter_paths(all_paths, !show_directories, |_, md| !md.is_dir())
 }

--- a/file/src/list/mod.rs
+++ b/file/src/list/mod.rs
@@ -908,6 +908,8 @@ fn filter_xvc_path_metadata_map(
         },
         (false, true) => |path: &XvcPath, _| !(path.starts_with_str(".") || path.contains("./")),
         (false, false) => |path: &XvcPath, md: &XvcMetadata| {
+            watch!(path);
+            watch!(md);
             !(path.starts_with_str(".") || path.contains("./") || md.is_dir())
         },
     };

--- a/file/src/list/mod.rs
+++ b/file/src/list/mod.rs
@@ -23,7 +23,7 @@ use xvc_core::{
     ContentDigest, HashAlgorithm, RecheckMethod, XvcFileType, XvcMetadata, XvcPath, XvcRoot,
 };
 use xvc_ecs::{HStore, XvcEntity, XvcStore};
-use xvc_logging::{error, output, watch, XvcOutputSender};
+use xvc_logging::{error, output, XvcOutputSender};
 
 /// Format specifier for file list columns
 #[derive(Debug, Clone, EnumString, EnumDisplay, PartialEq, Eq)]
@@ -511,7 +511,6 @@ impl Display for ListRows {
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(rename_all = "kebab-case")]
-
 pub struct ListCLI {
     /// A string for each row of the output table
     ///
@@ -625,7 +624,6 @@ impl UpdateFromXvcConfig for ListCLI {
 /// - <: File is newer, xvc carry-in to update the cache
 ///
 /// TODO: - I: File is ignored
-
 pub fn cmd_list(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, cli_opts: ListCLI) -> Result<()> {
     // FIXME: `opts` shouldn't be sent to the inner function, but we cannot make sure that it's
     // updated from the config files in callers. A refactoring is good here.
@@ -940,25 +938,4 @@ fn filter_xvc_path_xvc_metadata_stores(
             }
         })
         .collect()
-}
-
-fn filter_dot_files(
-    all_from_disk: HashMap<XvcPath, XvcMetadata>,
-    show_dot_files: bool,
-) -> HashMap<XvcPath, XvcMetadata> {
-    if show_dot_files {
-        all_from_disk
-    } else {
-        all_from_disk
-            .into_iter()
-            .filter_map(|(path, md)| {
-                let path_str = path.to_string();
-                if path_str.starts_with('.') || path_str.contains("./") {
-                    None
-                } else {
-                    Some((path, md))
-                }
-            })
-            .collect()
-    }
 }

--- a/file/src/mv/mod.rs
+++ b/file/src/mv/mod.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use xvc_config::FromConfigKey;
 use xvc_core::{RecheckMethod, XvcFileType, XvcMetadata, XvcPath, XvcRoot};
 use xvc_ecs::{HStore, XvcEntity, XvcStore};
-use xvc_logging::{info, uwr, watch, XvcOutputSender};
+use xvc_logging::{info, uwr, XvcOutputSender};
 
 /// CLI for `xvc file copy`.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]

--- a/file/src/recheck/mod.rs
+++ b/file/src/recheck/mod.rs
@@ -22,7 +22,7 @@ use xvc_core::{
     XvcMetadata, XvcPath, XvcRoot,
 };
 use xvc_ecs::{HStore, XvcEntity, XvcStore};
-use xvc_logging::{error, info, uwr, warn, watch, XvcOutputSender};
+use xvc_logging::{error, info, uwr, warn, XvcOutputSender};
 
 /// Check out file from cache by a copy or link
 ///

--- a/file/src/remove/mod.rs
+++ b/file/src/remove/mod.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use xvc_core::types::xvcdigest::DIGEST_LENGTH;
 use xvc_core::{XvcCachePath, XvcRoot};
 use xvc_ecs::XvcEntity;
-use xvc_logging::{output, uwr, warn, watch, XvcOutputSender};
+use xvc_logging::{output, uwr, warn, XvcOutputSender};
 use xvc_storage::storage::get_storage_record;
 use xvc_storage::{StorageIdentifier, XvcStorageOperations};
 

--- a/file/src/remove/mod.rs
+++ b/file/src/remove/mod.rs
@@ -93,10 +93,8 @@ pub fn cmd_remove(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: Remove
     } else if let Some(version) = opts.only_version {
         // Return only the cache paths that match the version prefix
         let version_cmp_str = version.replace('-', "");
-        watch!(version_cmp_str);
         let version_cmp = |v: &&XvcCachePath| {
             let digest_str = v.digest_string(DIGEST_LENGTH).replace('-', "");
-            watch!(digest_str);
             // We skip the first two characters because they are the hash algorithm identifier
             digest_str[2..].starts_with(&version_cmp_str)
         };
@@ -118,12 +116,9 @@ pub fn cmd_remove(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: Remove
                 Vec::<(XvcEntity, XvcCachePath)>::new(),
                 |mut acc, (xe, vec_cp)| {
                     vec_cp.into_iter().for_each(|xcp| acc.push((xe, xcp)));
-                    watch!(acc);
                     acc
                 },
             );
-
-        watch!(paths);
 
         if paths.len() > 1 {
             return Err(anyhow::anyhow!(
@@ -147,8 +142,6 @@ pub fn cmd_remove(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: Remove
             })
             .collect::<Vec<(XvcEntity, XvcCachePath)>>()
     };
-
-    watch!(candidate_paths);
 
     let mut entities_for_cache_path: HashMap<XvcCachePath, HashSet<XvcEntity>> = HashMap::new();
 
@@ -203,10 +196,9 @@ pub fn cmd_remove(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: Remove
     deletable_paths.sort_unstable();
 
     if opts.from_cache {
-        deletable_paths.iter().for_each(|xcp| {
-            watch!(xcp);
-            uwr!(xcp.remove(output_snd, xvc_root), output_snd)
-        });
+        deletable_paths
+            .iter()
+            .for_each(|xcp| uwr!(xcp.remove(output_snd, xvc_root), output_snd));
     }
 
     if let Some(storage) = opts.from_storage {

--- a/file/src/send/mod.rs
+++ b/file/src/send/mod.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 
 use xvc_core::{ContentDigest, XvcCachePath, XvcFileType, XvcMetadata, XvcRoot};
 use xvc_ecs::{HStore, XvcStore};
-use xvc_logging::{error, watch, XvcOutputSender};
+use xvc_logging::{error, XvcOutputSender};
 use xvc_storage::{storage::get_storage_record, StorageIdentifier, XvcStorageOperations};
 
 /// Send (upload) tracked files to storage

--- a/file/src/send/mod.rs
+++ b/file/src/send/mod.rs
@@ -35,10 +35,8 @@ pub struct SendCLI {
 /// Send a targets in `opts.targets` in `xvc_root`  to `opt.remote`
 pub fn cmd_send(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: SendCLI) -> Result<()> {
     let remote = get_storage_record(output_snd, xvc_root, &opts.storage)?;
-    watch!(remote);
     let current_dir = xvc_root.config().current_dir()?;
     let targets = load_targets_from_store(output_snd, xvc_root, current_dir, &opts.targets)?;
-    watch!(targets);
 
     let target_file_xvc_metadata = xvc_root
         .load_store::<XvcMetadata>()?
@@ -52,7 +50,6 @@ pub fn cmd_send(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: SendCLI)
     let content_digest_store: XvcStore<ContentDigest> = xvc_root.load_store()?;
 
     let target_content_digests = content_digest_store.subset(target_files.keys().copied())?;
-    watch!(target_content_digests);
 
     assert! {
         target_content_digests.len() == target_files.len(),
@@ -73,8 +70,6 @@ pub fn cmd_send(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: SendCLI)
             })
         })
         .collect();
-
-    watch!(cache_paths);
 
     remote
         .send(

--- a/file/src/share/mod.rs
+++ b/file/src/share/mod.rs
@@ -31,11 +31,9 @@ pub struct ShareCLI {
 pub fn cmd_share(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: ShareCLI) -> Result<()> {
     // TODO: TIDY UP these implementation to reuse code in other places
     let storage = get_storage_record(output_snd, xvc_root, &opts.storage)?;
-    watch!(storage);
     let current_dir = xvc_root.config().current_dir()?;
     let targets =
         load_targets_from_store(output_snd, xvc_root, current_dir, &Some(vec![opts.target]))?;
-    watch!(targets);
 
     let target_file_xvc_metadata = xvc_root
         .load_store::<XvcMetadata>()?
@@ -59,15 +57,9 @@ pub fn cmd_share(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: ShareCL
 
     let target_content_digest = uwo!(content_digest_store.get(target_file_e), output_snd);
 
-    watch!(target_content_digest);
-
     let cache_path = XvcCachePath::new(target_file, target_content_digest)?;
 
-    watch!(cache_path);
-
     let duration = humantime::parse_duration(&opts.duration)?;
-
-    watch!(duration);
 
     storage.share(output_snd, xvc_root, &cache_path, duration)?;
     Ok(())

--- a/file/src/track/mod.rs
+++ b/file/src/track/mod.rs
@@ -138,7 +138,6 @@ pub fn cmd_track(
         &opts.targets,
         filter_git_files,
     )?;
-    watch!(targets);
     let requested_recheck_method = opts.recheck_method;
     let text_or_binary = opts.text_or_binary.unwrap_or_default();
     let no_parallel = opts.no_parallel;
@@ -203,15 +202,12 @@ pub fn cmd_track(
         !no_parallel,
     );
 
-    watch!(content_digest_diff);
-
     update_store_records(xvc_root, &xvc_path_diff, true, false)?;
     update_store_records(xvc_root, &xvc_metadata_diff, true, false)?;
     update_store_records(xvc_root, &recheck_method_diff, true, false)?;
     update_store_records(xvc_root, &text_or_binary_diff, true, false)?;
     update_store_records(xvc_root, &content_digest_diff, true, false)?;
 
-    watch!(targets);
     let file_targets: Vec<XvcPath> = targets
         .iter()
         .filter_map(|(xp, xmd)| {
@@ -240,9 +236,6 @@ pub fn cmd_track(
         .collect();
 
     let current_gitignore = build_gitignore(xvc_root)?;
-
-    watch!(file_targets);
-    watch!(dir_targets);
 
     update_dir_gitignores(xvc_root, &current_gitignore, &dir_targets)?;
     // We reload gitignores here to make sure we ignore the given dirs
@@ -283,7 +276,6 @@ pub fn cmd_track(
                 })
             })
             .collect();
-        watch!(xvc_paths_to_carry);
 
         let cache_paths = updated_content_digest_store
             .iter()

--- a/file/src/untrack/mod.rs
+++ b/file/src/untrack/mod.rs
@@ -103,7 +103,6 @@ pub fn cmd_untrack(
     if let Some(restore_dir) = opts.restore_versions {
         const VERSION_ID_LEN: usize = 15;
         let abs_restore_dir = current_dir.join(restore_dir);
-        watch!(abs_restore_dir);
         if abs_restore_dir.is_file() {
             panic!(
                 output_snd,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,14 +20,14 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
-xvc-file = { version = "0.6.13-alpha.3", path = "../file", default-features = false }
-xvc-pipeline = { version = "0.6.13-alpha.3", path = "../pipeline" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.3", path = "../storage", default-features = false }
+xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
+xvc-file = { version = "0.6.13-alpha.4", path = "../file", default-features = false }
+xvc-pipeline = { version = "0.6.13-alpha.4", path = "../pipeline" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.4", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo"] }
@@ -133,4 +133,4 @@ shellfn = "^0.1"
 test-case = "^3.3"
 trycmd = "^0.15"
 which = "^7.0"
-xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,14 +20,14 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
-xvc-file = { version = "0.6.13-alpha.2", path = "../file", default-features = false }
-xvc-pipeline = { version = "0.6.13-alpha.2", path = "../pipeline" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.2", path = "../storage", default-features = false }
+xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
+xvc-file = { version = "0.6.13-alpha.3", path = "../file", default-features = false }
+xvc-pipeline = { version = "0.6.13-alpha.3", path = "../pipeline" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.3", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo"] }
@@ -133,4 +133,4 @@ shellfn = "^0.1"
 test-case = "^3.3"
 trycmd = "^0.15"
 which = "^7.0"
-xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
 xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
 xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
 xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-file = { version = "0.6.13-alpha.4", path = "../file", default-features = false }
+xvc-file = { version = "0.6.13-alpha.4", path = "../file" }
 xvc-pipeline = { version = "0.6.13-alpha.4", path = "../pipeline" }
 xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
 xvc-storage = { version = "0.6.13-alpha.4", path = "../storage", default-features = false }
@@ -91,7 +91,9 @@ predicates = "^3.1"
 
 
 [features]
-default = ["s3", "minio", "r2", "gcs", "wasabi", "digital-ocean", "reflink"]
+default = ["s3", "minio", "r2", "gcs", "wasabi", "digital-ocean"]
+# Dropped reflink from default features in 0.6.13
+reflink = ["xvc-file/reflink"]
 s3 = ["xvc-storage/s3"]
 minio = ["xvc-storage/minio"]
 r2 = ["xvc-storage/r2"]
@@ -100,7 +102,6 @@ wasabi = ["xvc-storage/wasabi"]
 digital-ocean = ["xvc-storage/digital-ocean"]
 bundled-sqlite = ["xvc-pipeline/bundled-sqlite"]
 bundled-openssl = ["xvc-storage/bundled-openssl"]
-reflink = ["xvc-file/reflink"]
 test-s3 = ["s3"]
 test-minio = ["minio"]
 test-r2 = ["r2"]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,14 +20,14 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-file = { version = "0.6.13-alpha.4", path = "../file" }
-xvc-pipeline = { version = "0.6.13-alpha.4", path = "../pipeline" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.4", path = "../storage", default-features = false }
+xvc-config = { version = "0.6.13-alpha.5", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.5", path = "../core" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.5", path = "../ecs" }
+xvc-file = { version = "0.6.13-alpha.5", path = "../file" }
+xvc-pipeline = { version = "0.6.13-alpha.5", path = "../pipeline" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.5", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo"] }
@@ -134,4 +134,4 @@ shellfn = "^0.1"
 test-case = "^3.3"
 trycmd = "^0.15"
 which = "^7.0"
-xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.5", path = "../test_helper/" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,14 +20,14 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.1", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.1", path = "../core" }
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-ecs = { version = "0.6.13-alpha.1", path = "../ecs" }
-xvc-file = { version = "0.6.13-alpha.1", path = "../file", default-features = false }
-xvc-pipeline = { version = "0.6.13-alpha.1", path = "../pipeline" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
-xvc-storage = { version = "0.6.13-alpha.1", path = "../storage", default-features = false }
+xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
+xvc-file = { version = "0.6.13-alpha.2", path = "../file", default-features = false }
+xvc-pipeline = { version = "0.6.13-alpha.2", path = "../pipeline" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-storage = { version = "0.6.13-alpha.2", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo"] }
@@ -133,4 +133,4 @@ shellfn = "^0.1"
 test-case = "^3.3"
 trycmd = "^0.15"
 which = "^7.0"
-xvc-test-helper = { version = "0.6.13-alpha.1", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }

--- a/lib/src/cli/mod.rs
+++ b/lib/src/cli/mod.rs
@@ -378,8 +378,6 @@ pub fn dispatch_with_root(cli_opts: cli::XvcCLI, xvc_root_opt: XvcRootOpt) -> Re
                 }
             };
 
-            watch!("Before handle_git_automation");
-
             match xvc_root_opt {
                 Some(ref xvc_root) => {
                     xvc_root.record();

--- a/lib/src/cli/mod.rs
+++ b/lib/src/cli/mod.rs
@@ -29,7 +29,6 @@ use xvc_core::root;
 use xvc_core::CHANNEL_BOUND;
 use xvc_file as file;
 use xvc_logging::setup_logging;
-use xvc_logging::watch;
 use xvc_pipeline as pipeline;
 use xvc_storage as storage;
 use xvc_walker::AbsolutePath;

--- a/lib/src/init/mod.rs
+++ b/lib/src/init/mod.rs
@@ -49,7 +49,6 @@ pub fn run(xvc_root_opt: Option<&XvcRoot>, opts: InitCLI) -> Result<XvcRoot> {
         .clone()
         .path
         .unwrap_or_else(|| env::current_dir().unwrap());
-    watch!(&path);
     // Check whether we are inside a repository
     match xvc_root_opt {
         Some(xvc_root) => {
@@ -95,10 +94,8 @@ pub fn run(xvc_root_opt: Option<&XvcRoot>, opts: InitCLI) -> Result<XvcRoot> {
         include_environment_config: true,
         command_line_config: None,
     };
-    watch!(config_opts);
 
     let xvc_root = init_xvc_root(&path, config_opts)?;
-    watch!(xvc_root);
     xvc_pipeline::init(&xvc_root)?;
     xvc_file::init(&xvc_root)?;
     Ok(xvc_root)

--- a/lib/src/init/mod.rs
+++ b/lib/src/init/mod.rs
@@ -10,7 +10,6 @@ use xvc_core::default_project_config;
 use xvc_core::types::xvcroot::init_xvc_root;
 use xvc_core::util::git::inside_git;
 use xvc_core::XvcRoot;
-use xvc_logging::watch;
 use xvc_pipeline;
 use xvc_walker::AbsolutePath;
 

--- a/lib/tests/common/mod.rs
+++ b/lib/tests/common/mod.rs
@@ -145,7 +145,7 @@ pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
 
 /// Create a temporary Xvc directory that's also Git repository
 pub fn run_in_temp_xvc_dir() -> Result<XvcRoot> {
-    let the_dir = run_in_temp_git_dir();
+    run_in_temp_git_dir();
     let xvc_root = xvc::init::run(
         None,
         InitCLI {

--- a/lib/tests/common/mod.rs
+++ b/lib/tests/common/mod.rs
@@ -10,7 +10,7 @@ use xvc::init::InitCLI;
 use xvc_config::XvcVerbosity;
 
 use xvc_core::XvcRoot;
-use xvc_logging::{output, watch};
+use xvc_logging::output;
 
 use xvc::error::{Error, Result};
 
@@ -118,9 +118,9 @@ pub fn run_in_example_project() -> Result<PathBuf> {
 }
 
 pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
-    let example_project_dir = run_in_example_project()?;
+    run_in_example_project()?;
     if with_git {
-        let output = Command::new("git").arg("init").output()?;
+        Command::new("git").arg("init").output()?;
         let xvc_root = xvc::init::run(
             None,
             InitCLI {

--- a/lib/tests/common/mod.rs
+++ b/lib/tests/common/mod.rs
@@ -34,16 +34,11 @@ pub fn run_xvc(cwd: Option<&Path>, args: &[&str], verbosity: XvcVerbosity) -> Re
         XvcVerbosity::Trace => vec!["--debug", "-vvvvv"],
     };
 
-    // watch!(cmd);
-    // watch!(verbosity_opt);
-    // watch!(args);
-
     let prepared = match cwd {
         Some(cwd) => cmd.args(verbosity_opt).args(args).current_dir(cwd),
         None => cmd.args(verbosity_opt).args(args),
     };
 
-    watch!(prepared);
     let output = prepared.output()?;
 
     output!("{:?}", &output);
@@ -124,10 +119,8 @@ pub fn run_in_example_project() -> Result<PathBuf> {
 
 pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
     let example_project_dir = run_in_example_project()?;
-    watch!(example_project_dir);
     if with_git {
         let output = Command::new("git").arg("init").output()?;
-        watch!(output);
         let xvc_root = xvc::init::run(
             None,
             InitCLI {
@@ -136,7 +129,6 @@ pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
                 force: false,
             },
         )?;
-        watch!(xvc_root);
         Ok(xvc_root)
     } else {
         let xvc_root = xvc::init::run(
@@ -147,7 +139,6 @@ pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
                 force: false,
             },
         )?;
-        watch!(xvc_root);
         Ok(xvc_root)
     }
 }
@@ -155,7 +146,6 @@ pub fn run_in_example_xvc(with_git: bool) -> Result<XvcRoot> {
 /// Create a temporary Xvc directory that's also Git repository
 pub fn run_in_temp_xvc_dir() -> Result<XvcRoot> {
     let the_dir = run_in_temp_git_dir();
-    watch!(&the_dir);
     let xvc_root = xvc::init::run(
         None,
         InitCLI {
@@ -164,7 +154,6 @@ pub fn run_in_temp_xvc_dir() -> Result<XvcRoot> {
             force: false,
         },
     )?;
-    // watch!(xvc_root);
     Ok(xvc_root)
 }
 

--- a/lib/tests/test_core_root.rs
+++ b/lib/tests/test_core_root.rs
@@ -13,11 +13,7 @@ fn test_root() -> Result<()> {
     test_logging(log::LevelFilter::Trace);
     let xvc_root = run_in_temp_xvc_dir()?;
 
-    watch!(xvc_root);
-
     let rel = run_xvc(Some(&xvc_root), &["root"], XvcVerbosity::Default)?;
-    watch!(rel);
-    watch!("After root");
     // assert!(
     //     rel.trim().to_string() == ".".to_string(),
     //     "Relative: {}",
@@ -29,9 +25,7 @@ fn test_root() -> Result<()> {
         XvcVerbosity::Default,
     )?;
 
-    watch!(abs);
     assert!(AbsolutePath::from(abs.trim().to_string()) == xvc_root.absolute_path().clone());
     clean_up(&xvc_root).map_err(|e| anyhow::anyhow!("Cleanup error: {e:?}"))?;
-    watch!("cleaned up");
     Ok(())
 }

--- a/lib/tests/test_core_util_file_pmp.rs
+++ b/lib/tests/test_core_util_file_pmp.rs
@@ -14,7 +14,6 @@ fn test_pmp() -> Result<()> {
     test_logging(LevelFilter::Trace);
     let (output_sender, _) = crossbeam_channel::unbounded();
     let xvc_root = run_in_temp_xvc_dir()?;
-    watch!(xvc_root);
 
     // We create this directory tree BEFORE the pmp so that we'll assert that it won't be notified
     // and won't collect these.
@@ -49,10 +48,8 @@ fn test_pmp() -> Result<()> {
     let new_size = 200;
     generate_random_file(&path1, new_size, None);
     let xmd1_real = XvcMetadata::from(path1.symlink_metadata());
-    watch!(xmd1_real);
     sleep(Duration::from_millis(100));
     let xmd1 = pmp.get(&xpath1);
-    watch!(xmd1);
     assert!(xmd1.is_some());
     assert!(xmd1.unwrap().is_file());
     assert!(xmd1.unwrap().size == Some(new_size as u64), "{:?}", xmd1);
@@ -63,7 +60,6 @@ fn test_pmp() -> Result<()> {
     assert!(!pmp.path_present(&xpath1));
 
     let glob_paths = pmp.glob_paths("**/*.bin")?;
-    watch!(glob_paths);
     assert!(glob_paths.len() == n_dirs * n_files);
 
     remove_file(Path::new("dir-0001/file-0001.bin"))?;

--- a/lib/tests/test_core_util_file_walker.rs
+++ b/lib/tests/test_core_util_file_walker.rs
@@ -18,7 +18,6 @@ fn test_walk() -> Result<()> {
     test_logging(LevelFilter::Trace);
     let (output_sender, output_receiver) = crossbeam_channel::unbounded();
     let xvc_root = run_in_example_xvc(true)?;
-    watch!(xvc_root);
 
     let (pmp1, _) = walk_serial(&output_sender, &xvc_root, true)?;
 
@@ -36,23 +35,18 @@ fn test_walk() -> Result<()> {
     assert!(!path_set2.is_empty());
 
     let diff1: HashSet<&XvcPath> = path_set1.difference(&path_set2).collect();
-    watch!(diff1);
 
     let diff2: HashSet<&XvcPath> = path_set2.difference(&path_set1).collect();
-
-    watch!(diff2);
 
     assert!(diff1.is_empty());
     assert!(diff2.is_empty());
 
     let mut output_lines = Vec::<String>::new();
-    watch!(output_lines);
     while let Ok(Some(l)) = output_receiver.recv_timeout(Duration::from_secs(1)) {
         output_lines.push(l.to_string());
     }
 
     let output = output_lines.into_iter().collect::<Vec<String>>().join("\n");
-    watch!(output);
 
     for (p, m) in pmp1 {
         assert!(pmp2[&p] == m)

--- a/lib/tests/test_core_util_notify.rs
+++ b/lib/tests/test_core_util_notify.rs
@@ -22,7 +22,6 @@ use xvc_walker::{walk_serial, WalkOptions};
 fn test_notify() -> Result<()> {
     let temp_dir = TempDir::new()?;
     env::set_current_dir(&temp_dir)?;
-    watch!(temp_dir);
     test_logging(log::LevelFilter::Trace);
     let walk_options = WalkOptions {
         ignore_filename: Some(XVCIGNORE_FILENAME.to_owned()),
@@ -39,7 +38,6 @@ fn test_notify() -> Result<()> {
     let files_len = files.len();
 
     files.iter().for_each(|f| {
-        watch!(f.path());
         f.touch().unwrap();
     });
     const MAX_ERROR_COUNT: usize = 10;
@@ -52,18 +50,13 @@ fn test_notify() -> Result<()> {
         &temp_dir,
         &walk_options,
     )?;
-    watch!(all_rules);
     assert!(output_receiver.is_empty());
     let (watcher, receiver) = make_polling_watcher(all_rules)?;
-    watch!(watcher);
-    watch!(initial_paths.len());
 
     let event_handler = thread::spawn(move || {
         let mut err_counter = MAX_ERROR_COUNT;
         loop {
-            watch!(receiver);
             let r = receiver.try_recv();
-            watch!(r);
             if let Ok(Some(pe)) = r {
                 err_counter = MAX_ERROR_COUNT;
                 match pe {
@@ -83,26 +76,21 @@ fn test_notify() -> Result<()> {
                 break;
             }
 
-            watch!(err_counter);
             sleep(Duration::from_millis(
                 ((MAX_ERROR_COUNT - err_counter) * 100) as u64,
             ));
         }
-        watch!(err_counter);
-        watch!(receiver);
     });
 
     sleep(Duration::from_millis(3000));
     let size_updated = 20;
 
     files.iter().for_each(|f| {
-        watch!(f.path());
         f.write_binary(&vec![0; size_updated]).unwrap();
     });
 
     sleep(Duration::from_millis(3000));
     files.iter().for_each(|f| {
-        watch!(f.path());
         remove_file(f.path()).unwrap();
     });
 
@@ -112,22 +100,18 @@ fn test_notify() -> Result<()> {
 
     {
         let created_paths = created_paths_rec.iter().collect::<Vec<PathBuf>>();
-        watch!(created_paths);
         let len = created_paths.len();
-        watch!(len);
         // This also gets the directory creation event itself
         assert!(len == files_len + 1);
     }
     // TODO: This is not working for some reason on macOS
     // {
     //     let updated_paths = updated_paths_rec.iter().collect::<Vec<PathBuf>>();
-    //     watch!(updated_paths);
     //     assert_eq!(updated_paths.len(), files_len);
     // }
 
     {
         let deleted_paths = deleted_paths_rec.iter().collect::<Vec<PathBuf>>();
-        watch!(deleted_paths);
         assert_eq!(deleted_paths.len(), files_len);
     }
 

--- a/lib/tests/test_core_util_notify.rs
+++ b/lib/tests/test_core_util_notify.rs
@@ -11,7 +11,6 @@ use std::time::Duration;
 
 use xvc::error::Result;
 
-use xvc::watch;
 use xvc_core::util::xvcignore::COMMON_IGNORE_PATTERNS;
 use xvc_core::XVCIGNORE_FILENAME;
 
@@ -44,14 +43,14 @@ fn test_notify() -> Result<()> {
 
     let (output_sender, output_receiver) = crossbeam_channel::unbounded();
 
-    let (initial_paths, all_rules) = walk_serial(
+    let (_initial_paths, all_rules) = walk_serial(
         &output_sender,
         COMMON_IGNORE_PATTERNS,
         &temp_dir,
         &walk_options,
     )?;
     assert!(output_receiver.is_empty());
-    let (watcher, receiver) = make_polling_watcher(all_rules)?;
+    let (_watcher, receiver) = make_polling_watcher(all_rules)?;
 
     let event_handler = thread::spawn(move || {
         let mut err_counter = MAX_ERROR_COUNT;

--- a/lib/tests/test_file_list.rs
+++ b/lib/tests/test_file_list.rs
@@ -101,8 +101,8 @@ fn test_file_list() -> Result<()> {
 
     // There must be 30 elements in total. 6 x 5: directories and files
     assert!(
-        count_no_dots_no_summary == 25,
-        "count_no_dots_no_dirs_no_summary: {} {}",
+        count_no_dots_no_summary == 30,
+        "count_no_dots_no_summary: {} {}",
         count_no_dots_no_summary,
         list_no_dots_no_summary
     );

--- a/lib/tests/test_file_list.rs
+++ b/lib/tests/test_file_list.rs
@@ -59,7 +59,12 @@ fn test_file_list() -> Result<()> {
     let count_no_dots = count_lines(&list_no_dots);
     // There must be 33 elements in total. 6 x 5: directories another line for the summary and a
     // space between them.
-    assert!(count_no_dots == 31, "count_no_dots: {}", count_no_dots);
+    assert!(
+        count_no_dots == 31,
+        "count_no_dots: {}; list_no_dots: {}",
+        count_no_dots,
+        list_no_dots
+    );
 
     let list_all = x(&[
         "list",
@@ -67,6 +72,7 @@ fn test_file_list() -> Result<()> {
         "{{name}}",
         "--show-dot-files",
         "--include-git-files",
+        "--show-directories",
     ])?;
 
     let count_all = count_lines(&list_all);
@@ -74,13 +80,30 @@ fn test_file_list() -> Result<()> {
     // space before summary.
     assert!(count_all == 33, "count_all: {}", count_all);
 
-    let list_no_dots_no_summary = x(&["list", "--format", "{{name}}", "--no-summary"])?;
+    let list_no_dots_no_dirs_no_summary = x(&["list", "--format", "{{name}}", "--no-summary"])?;
+    let count_no_dots_no_dirs_no_summary = count_lines(&list_no_dots_no_dirs_no_summary);
+
+    // There must be 25 elements in total. 5 x 5: files and a new line.
+    assert!(
+        count_no_dots_no_dirs_no_summary == 25,
+        "count_no_dots_no_dirs_no_summary: {} {}",
+        count_no_dots_no_dirs_no_summary,
+        list_no_dots_no_dirs_no_summary
+    );
+
+    let list_no_dots_no_summary = x(&[
+        "list",
+        "--format",
+        "{{name}}",
+        "--no-summary",
+        "--show-dirs",
+    ])?;
     let count_no_dots_no_summary = count_lines(&list_no_dots_no_summary);
 
-    // There must be 31 elements in total. 6 x 5: directories and a new line.
+    // There must be 30 elements in total. 6 x 5: directories and files
     assert!(
-        count_no_dots_no_summary == 30,
-        "count_no_dots_no_summary: {} {}",
+        count_no_dots_no_summary == 25,
+        "count_no_dots_no_dirs_no_summary: {} {}",
         count_no_dots_no_summary,
         list_no_dots_no_summary
     );
@@ -104,6 +127,7 @@ fn test_file_list() -> Result<()> {
             sort_option,
             "dir-0001",
         ])?;
+
         let top_line = cmd_res.lines().next().unwrap();
         assert!(
             top_line.ends_with(top_element),

--- a/lib/tests/test_file_list.rs
+++ b/lib/tests/test_file_list.rs
@@ -55,7 +55,7 @@ fn test_file_list() -> Result<()> {
     };
 
     let count_lines = |s: &str| s.trim().lines().filter(|l| !l.trim().is_empty()).count();
-    let list_no_dots = x(&["list", "--format", "{{name}}"])?;
+    let list_no_dots = x(&["list", "--format", "{{name}} {{rcd8}} {{acd8}}"])?;
     let count_no_dots = count_lines(&list_no_dots);
     // There must be 26 elements in total. 5 x 5: files and a line for the summary
     assert!(

--- a/lib/tests/test_file_list.rs
+++ b/lib/tests/test_file_list.rs
@@ -57,10 +57,9 @@ fn test_file_list() -> Result<()> {
     let count_lines = |s: &str| s.trim().lines().filter(|l| !l.trim().is_empty()).count();
     let list_no_dots = x(&["list", "--format", "{{name}}"])?;
     let count_no_dots = count_lines(&list_no_dots);
-    // There must be 33 elements in total. 6 x 5: directories another line for the summary and a
-    // space between them.
+    // There must be 26 elements in total. 5 x 5: files and a line for the summary
     assert!(
-        count_no_dots == 31,
+        count_no_dots == 26,
         "count_no_dots: {}; list_no_dots: {}",
         count_no_dots,
         list_no_dots

--- a/lib/tests/test_file_recheck_parallel.rs
+++ b/lib/tests/test_file_recheck_parallel.rs
@@ -29,9 +29,11 @@ fn test_file_recheck_parallel() -> Result<()> {
 
     let file_to_add = "file-0000.bin";
     let path_to_add = PathBuf::from(file_to_add);
+    x(&["file", "track", file_to_add])?;
     assert!(path_to_add.exists());
     fs::remove_file(file_to_add)?;
     assert!(!path_to_add.exists());
+    x(&["file", "recheck", file_to_add])?;
 
     assert!(
         PathBuf::from(file_to_add).exists(),

--- a/lib/tests/test_file_recheck_parallel.rs
+++ b/lib/tests/test_file_recheck_parallel.rs
@@ -4,7 +4,6 @@ use log::LevelFilter;
 use std::{fs, path::PathBuf};
 
 use xvc::error::Result;
-use xvc::watch;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::{create_directory_tree, generate_filled_file};

--- a/lib/tests/test_file_recheck_parallel.rs
+++ b/lib/tests/test_file_recheck_parallel.rs
@@ -29,11 +29,9 @@ fn test_file_recheck_parallel() -> Result<()> {
 
     let file_to_add = "file-0000.bin";
     let path_to_add = PathBuf::from(file_to_add);
-    watch!(x(&["file", "track", file_to_add])?);
     assert!(path_to_add.exists());
     fs::remove_file(file_to_add)?;
     assert!(!path_to_add.exists());
-    watch!(x(&["file", "recheck", file_to_add])?);
 
     assert!(
         PathBuf::from(file_to_add).exists(),

--- a/lib/tests/test_file_recheck_serial.rs
+++ b/lib/tests/test_file_recheck_serial.rs
@@ -4,7 +4,7 @@ use std::{fs, path::PathBuf};
 
 use crate::common::run_in_temp_xvc_dir;
 use log::LevelFilter;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::{create_directory_tree, generate_filled_file};

--- a/lib/tests/test_file_recheck_serial.rs
+++ b/lib/tests/test_file_recheck_serial.rs
@@ -31,9 +31,11 @@ fn test_file_recheck_serial() -> Result<()> {
 
     let file_to_add = "file-0000.bin";
     let path_to_add = PathBuf::from(file_to_add);
+    x(&["file", "track", file_to_add])?;
     assert!(path_to_add.exists());
     fs::remove_file(file_to_add)?;
     assert!(!path_to_add.exists());
+    x(&["file", "recheck", "--no-parallel", file_to_add])?;
 
     assert!(PathBuf::from(file_to_add).exists());
 

--- a/lib/tests/test_file_recheck_serial.rs
+++ b/lib/tests/test_file_recheck_serial.rs
@@ -31,11 +31,9 @@ fn test_file_recheck_serial() -> Result<()> {
 
     let file_to_add = "file-0000.bin";
     let path_to_add = PathBuf::from(file_to_add);
-    watch!(x(&["file", "track", file_to_add])?);
     assert!(path_to_add.exists());
     fs::remove_file(file_to_add)?;
     assert!(!path_to_add.exists());
-    watch!(x(&["file", "recheck", "--no-parallel", file_to_add])?);
 
     assert!(PathBuf::from(file_to_add).exists());
 

--- a/lib/tests/test_file_track_issue_104.rs
+++ b/lib/tests/test_file_track_issue_104.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::Path;
 
 use xvc::error::Result;
-use xvc::watch;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::create_directory_tree;
@@ -30,7 +29,7 @@ fn test_file_track_issue_104() -> Result<()> {
     };
 
     let dir_1 = "dir-0001/";
-    let track_dir_1 = x(&["track", dir_1, "--no-parallel"])?;
+    x(&["track", dir_1, "--no-parallel"])?;
     // Create dir-0001 and dir-0002 with files file-0001..0010.bin inside them.
 
     let root_gitignore = fs::read_to_string(xvc_root.join(Path::new(".gitignore")))?;

--- a/lib/tests/test_file_track_issue_104.rs
+++ b/lib/tests/test_file_track_issue_104.rs
@@ -31,15 +31,10 @@ fn test_file_track_issue_104() -> Result<()> {
 
     let dir_1 = "dir-0001/";
     let track_dir_1 = x(&["track", dir_1, "--no-parallel"])?;
-    watch!(track_dir_1);
     // Create dir-0001 and dir-0002 with files file-0001..0010.bin inside them.
 
     let root_gitignore = fs::read_to_string(xvc_root.join(Path::new(".gitignore")))?;
-    watch!(root_gitignore);
     let dir_ignore = xvc_root.join(Path::new("dir-0001/.gitignore"));
-    watch!(dir_ignore);
-
-    watch!(std::fs::read_dir(dir_1)?);
 
     assert!(!dir_ignore.exists());
 

--- a/lib/tests/test_file_track_parallel.rs
+++ b/lib/tests/test_file_track_parallel.rs
@@ -52,9 +52,7 @@ fn test_file_track_parallel() -> Result<()> {
         ".xvc/b3/a57/262/2134fcb28679d2de66d225cc2a41c2594baa909781c0726eb7702baeb1/0.bin";
     let file_0 = "file-0000.bin";
     let track_file_0 = x(&["track", file_0])?;
-    watch!(track_file_0);
     let cache_path = xvc_root.absolute_path().join(images_cache_path);
-    watch!(cache_path);
 
     assert!(cache_path.exists());
 
@@ -67,7 +65,6 @@ fn test_file_track_parallel() -> Result<()> {
     );
 
     let gitignore_1 = fs::read_to_string(&gitignore_file_1)?;
-    watch!(gitignore_1);
 
     assert!(
         gitignore_1.lines().filter(|l| l.ends_with(file_0)).count() == 1,
@@ -87,7 +84,6 @@ fn test_file_track_parallel() -> Result<()> {
         .count();
 
     let track_dir_to_add = x(&["track", dir_to_add])?;
-    watch!(track_dir_to_add);
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3")
         .into_iter()
@@ -126,7 +122,6 @@ fn test_file_track_parallel() -> Result<()> {
     let n_files_before = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
     // re add should change n_files
     let second_add = x(&["track", file_0])?;
-    watch!(second_add);
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
     assert!(

--- a/lib/tests/test_file_track_parallel.rs
+++ b/lib/tests/test_file_track_parallel.rs
@@ -8,7 +8,6 @@ use std::{fs, path::PathBuf};
 use crate::common::run_in_temp_xvc_dir;
 use regex::Regex;
 use xvc::error::{Error, Result};
-use xvc::watch;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::{create_directory_tree, generate_filled_file};
@@ -51,7 +50,7 @@ fn test_file_track_parallel() -> Result<()> {
     let images_cache_path =
         ".xvc/b3/a57/262/2134fcb28679d2de66d225cc2a41c2594baa909781c0726eb7702baeb1/0.bin";
     let file_0 = "file-0000.bin";
-    let track_file_0 = x(&["track", file_0])?;
+    x(&["track", file_0])?;
     let cache_path = xvc_root.absolute_path().join(images_cache_path);
 
     assert!(cache_path.exists());
@@ -83,7 +82,7 @@ fn test_file_track_parallel() -> Result<()> {
         })
         .count();
 
-    let track_dir_to_add = x(&["track", dir_to_add])?;
+    x(&["track", dir_to_add])?;
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3")
         .into_iter()
@@ -121,7 +120,7 @@ fn test_file_track_parallel() -> Result<()> {
 
     let n_files_before = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
     // re add should change n_files
-    let second_add = x(&["track", file_0])?;
+    x(&["track", file_0])?;
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
     assert!(

--- a/lib/tests/test_file_track_serial.rs
+++ b/lib/tests/test_file_track_serial.rs
@@ -26,7 +26,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -58,9 +57,7 @@ fn test_file_track_serial() -> Result<()> {
         ".xvc/b3/a57/262/2134fcb28679d2de66d225cc2a41c2594baa909781c0726eb7702baeb1/0.bin";
     let file_0 = "file-0000.bin";
     let track_file_0 = x(&["track", file_0, "--no-parallel"])?;
-    watch!(track_file_0);
     let cache_path = xvc_root.absolute_path().join(images_cache_path);
-    watch!(cache_path);
 
     assert!(cache_path.exists());
 
@@ -73,7 +70,6 @@ fn test_file_track_serial() -> Result<()> {
     );
 
     let gitignore_1 = fs::read_to_string(&gitignore_file_1)?;
-    watch!(gitignore_1);
 
     assert!(
         gitignore_1.lines().filter(|l| l.ends_with(file_0)).count() == 1,
@@ -86,7 +82,6 @@ fn test_file_track_serial() -> Result<()> {
     let n_files_before = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
 
     let second_add = x(&["track", file_0, "--no-parallel"])?;
-    watch!(second_add);
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3").into_iter().count();
     assert!(
@@ -115,12 +110,10 @@ fn test_file_track_serial() -> Result<()> {
         })
         .count();
     let track_dir_to_add = x(&["track", dir_to_add, "--no-parallel"])?;
-    watch!(track_dir_to_add);
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3")
         .into_iter()
         .filter(|f| {
-            watch!(f);
             f.as_ref()
                 .map(|f| f.file_type().is_file())
                 .unwrap_or_else(|_| false)

--- a/lib/tests/test_file_track_serial.rs
+++ b/lib/tests/test_file_track_serial.rs
@@ -8,7 +8,6 @@ use std::{fs, path::PathBuf};
 use regex::Regex;
 use subprocess::Exec;
 use xvc::error::{Error, Result};
-use xvc::watch;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::{create_directory_tree, generate_filled_file};
@@ -109,7 +108,7 @@ fn test_file_track_serial() -> Result<()> {
                 .unwrap_or_else(|_| false)
         })
         .count();
-    let track_dir_to_add = x(&["track", dir_to_add, "--no-parallel"])?;
+    x(&["track", dir_to_add, "--no-parallel"])?;
 
     let n_files_after = jwalk::WalkDir::new(".xvc/b3")
         .into_iter()

--- a/lib/tests/test_init_3.rs
+++ b/lib/tests/test_init_3.rs
@@ -15,7 +15,6 @@ use xvc::watch;
 #[test]
 fn test_init_with_preexisting_git() -> Result<()> {
     let the_dir = common::run_in_temp_git_dir();
-    watch!(&the_dir);
     let previously_ignored = "dir-0001";
     fs::write(the_dir.join(".gitignore"), "{previously_ignored}\n")?;
     let xvc_root = xvc::init::run(

--- a/lib/tests/test_init_3.rs
+++ b/lib/tests/test_init_3.rs
@@ -7,7 +7,6 @@ use xvc::init::InitCLI;
 use xvc::error::Result;
 
 use common::*;
-use xvc::watch;
 
 // This tests the preexisting .gitignore rules bug
 // https://github.com/iesahin/xvc/issues/119

--- a/lib/tests/test_pipeline.rs
+++ b/lib/tests/test_pipeline.rs
@@ -2,7 +2,6 @@ mod common;
 
 use common::*;
 use xvc::error::Result;
-use xvc::watch;
 use xvc_config::XvcVerbosity;
 
 #[test]
@@ -35,7 +34,7 @@ fn test_pipeline() -> Result<()> {
     let pipelines_2 = x(&["list"])?;
     assert!(!pipelines_2.contains("pipeline-old"));
 
-    let res = x(&[
+    x(&[
         "-p",
         "pipeline-2",
         "step",

--- a/lib/tests/test_pipeline.rs
+++ b/lib/tests/test_pipeline.rs
@@ -2,8 +2,8 @@ mod common;
 
 use common::*;
 use xvc::error::Result;
-use xvc_config::XvcVerbosity;
 use xvc::watch;
+use xvc_config::XvcVerbosity;
 
 #[test]
 fn test_pipeline() -> Result<()> {
@@ -45,8 +45,6 @@ fn test_pipeline() -> Result<()> {
         "--command",
         "touch abc.txt",
     ])?;
-
-    watch!(res);
 
     x(&[
         "-p",

--- a/lib/tests/test_pipeline_command_process.rs
+++ b/lib/tests/test_pipeline_command_process.rs
@@ -7,7 +7,6 @@ use xvc_pipeline::{CommandProcess, XvcStep, XvcStepCommand};
 
 use xvc::error::Result;
 
-use xvc::watch;
 use xvc_test_helper::{create_directory_tree, test_logging};
 
 #[test]

--- a/lib/tests/test_pipeline_command_process.rs
+++ b/lib/tests/test_pipeline_command_process.rs
@@ -7,8 +7,8 @@ use xvc_pipeline::{CommandProcess, XvcStep, XvcStepCommand};
 
 use xvc::error::Result;
 
-use xvc_test_helper::{create_directory_tree, test_logging};
 use xvc::watch;
+use xvc_test_helper::{create_directory_tree, test_logging};
 
 #[test]
 fn test_pipeline_command_process() -> Result<()> {
@@ -19,7 +19,6 @@ fn test_pipeline_command_process() -> Result<()> {
     let n_files = 100;
 
     create_directory_tree(&xvc_root, n_dirs, n_files, 1, None)?;
-    watch!(xvc_root);
 
     let mut cp = CommandProcess::new(
         &XvcStep {
@@ -30,25 +29,17 @@ fn test_pipeline_command_process() -> Result<()> {
         },
     );
 
-    watch!(cp);
-
     cp.run()?;
 
-    watch!(cp);
-
     cp.update_output_channels()?;
-
-    watch!(cp);
 
     let mut n_total: usize = 0;
 
     while let Ok(l) = cp.stdout_receiver.recv_timeout(Duration::from_millis(10)) {
         n_total += l.split('\n').count();
         assert!(l.contains(".bin"));
-        watch!(l);
     }
 
-    watch!(n_total);
     assert_eq!(n_total, n_dirs * n_files + 1);
 
     Ok(())

--- a/lib/tests/test_pipeline_run.rs
+++ b/lib/tests/test_pipeline_run.rs
@@ -50,7 +50,6 @@ fn test_pipeline_run() -> Result<()> {
     };
 
     create_pipeline()?;
-    watch!("Before first");
     let _run_res = x(&["run"])?;
     println!("run_res: {}", _run_res);
     assert!(Path::new("src-files.txt").exists());

--- a/lib/tests/test_storage_list.rs
+++ b/lib/tests/test_storage_list.rs
@@ -42,11 +42,7 @@ fn test_storage_list() -> Result<()> {
         storage_dir.to_string_lossy().as_ref(),
     ])?;
 
-    watch!(out);
-
     let list_out = x(&["storage", "list"])?;
-
-    watch!(list_out);
 
     // The output table should contain
     // - name

--- a/lib/tests/test_storage_list.rs
+++ b/lib/tests/test_storage_list.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 use common::*;
 use regex::Regex;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_test_helper::{create_directory_tree, generate_filled_file};
@@ -32,7 +32,7 @@ fn test_storage_list() -> Result<()> {
         common::run_xvc(Some(&xvc_root), cmd, XvcVerbosity::Trace)
     };
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "local",

--- a/lib/tests/test_storage_new_digital_ocean.rs
+++ b/lib/tests/test_storage_new_digital_ocean.rs
@@ -129,7 +129,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -168,18 +167,15 @@ fn test_storage_new_digital_ocean() -> Result<()> {
         region,
     ])?;
 
-    watch!(out);
     let s3_bucket_list = s3cmd(
         &format!("ls --recursive 's3://{bucket_name}/'"),
         &format!("| rg {storage_prefix} | rg {XVC_STORAGE_GUID_FILENAME}"),
     );
-    watch!(s3_bucket_list);
     assert!(!s3_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let cache_dir = xvc_root.xvc_dir().join("b3");
 
@@ -187,16 +183,13 @@ fn test_storage_new_digital_ocean() -> Result<()> {
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_before);
     let n_storage_files_before = file_list_before.lines().count();
     let push_result = x(&["file", "send", "--to", "do-storage", the_file])?;
-    watch!(push_result);
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_after);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -215,8 +208,6 @@ fn test_storage_new_digital_ocean() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "do-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -233,7 +224,6 @@ fn test_storage_new_digital_ocean() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "do-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -245,7 +235,6 @@ fn test_storage_new_digital_ocean() -> Result<()> {
         .count();
 
     assert!(n_storage_files_after == n_local_files_after_pull);
-    watch!(the_file);
     assert!(PathBuf::from(the_file).exists());
 
     // Set remote specific passwords and remove DO ones
@@ -256,7 +245,6 @@ fn test_storage_new_digital_ocean() -> Result<()> {
     env::remove_var("DIGITAL_OCEAN_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "do-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_digital_ocean.rs
+++ b/lib/tests/test_storage_new_digital_ocean.rs
@@ -206,7 +206,7 @@ fn test_storage_new_digital_ocean() -> Result<()> {
     // remove all cache
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "do-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "do-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -223,7 +223,7 @@ fn test_storage_new_digital_ocean() -> Result<()> {
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
     fs::remove_file(the_file)?;
 
-    let pull_result = x(&["file", "bring", "--from", "do-storage"])?;
+    x(&["file", "bring", "--from", "do-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -244,7 +244,7 @@ fn test_storage_new_digital_ocean() -> Result<()> {
     env::remove_var("DIGITAL_OCEAN_ACCESS_KEY_ID");
     env::remove_var("DIGITAL_OCEAN_SECRET_ACCESS_KEY");
 
-    let pull_result_2 = x(&["file", "bring", "--from", "do-storage"])?;
+    x(&["file", "bring", "--from", "do-storage"])?;
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_gcs.rs
+++ b/lib/tests/test_storage_new_gcs.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 use common::*;
 use subprocess::Exec;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;

--- a/lib/tests/test_storage_new_gcs.rs
+++ b/lib/tests/test_storage_new_gcs.rs
@@ -126,7 +126,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -143,7 +142,6 @@ fn test_storage_new_gcs() -> Result<()> {
     let region = "europe-west3";
 
     let config_file_name = write_s3cmd_config(&access_key, &secret_key)?;
-    watch!(config_file_name);
 
     let s3cmd = |cmd: &str, append: &str| -> String {
         let sh_cmd = format!("s3cmd --config {config_file_name} {cmd} {append}");
@@ -168,18 +166,15 @@ fn test_storage_new_gcs() -> Result<()> {
         region,
     ])?;
 
-    watch!(out);
     let s3_bucket_list = s3cmd(
         &format!("ls --recursive 's3://{bucket_name}/'"),
         &format!("| rg {storage_prefix} | rg {XVC_STORAGE_GUID_FILENAME}"),
     );
-    watch!(s3_bucket_list);
     assert!(!s3_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let cache_dir = xvc_root.xvc_dir().join("b3");
 
@@ -187,10 +182,8 @@ fn test_storage_new_gcs() -> Result<()> {
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_before);
     let n_storage_files_before = file_list_before.lines().count();
     let push_result = x(&["file", "send", "--to", "gcs-storage", the_file])?;
-    watch!(push_result);
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),

--- a/lib/tests/test_storage_new_gcs.rs
+++ b/lib/tests/test_storage_new_gcs.rs
@@ -189,7 +189,6 @@ fn test_storage_new_gcs() -> Result<()> {
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_after);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -208,8 +207,6 @@ fn test_storage_new_gcs() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "gcs-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -226,7 +223,6 @@ fn test_storage_new_gcs() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "gcs-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -248,7 +244,6 @@ fn test_storage_new_gcs() -> Result<()> {
     env::remove_var("GCS_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "gcs-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_generic_fs.rs
+++ b/lib/tests/test_storage_new_generic_fs.rs
@@ -65,7 +65,7 @@ fn test_storage_new_generic_fs() -> Result<()> {
 
     let the_file = "file-0000.bin";
 
-    let file_track_result = x(&["file", "track", the_file])?;
+    x(&["file", "track", the_file])?;
 
     let n_storage_files_before = jwalk::WalkDir::new(&storage_dir)
         .into_iter()
@@ -76,7 +76,7 @@ fn test_storage_new_generic_fs() -> Result<()> {
         })
         .count();
 
-    let push_result = x(&["file", "send", "--to", "generic-storage", the_file])?;
+    x(&["file", "send", "--to", "generic-storage", the_file])?;
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin

--- a/lib/tests/test_storage_new_generic_fs.rs
+++ b/lib/tests/test_storage_new_generic_fs.rs
@@ -59,9 +59,6 @@ fn test_storage_new_generic_fs() -> Result<()> {
 
     let storage_dir = PathBuf::from(temp_directory).join(storage_dir_name);
 
-    watch!(storage_dir);
-    watch!(out);
-
     assert!(storage_dir.exists());
 
     assert!(storage_dir.join(XVC_STORAGE_GUID_FILENAME).exists());
@@ -69,7 +66,6 @@ fn test_storage_new_generic_fs() -> Result<()> {
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let n_storage_files_before = jwalk::WalkDir::new(&storage_dir)
         .into_iter()
@@ -80,10 +76,7 @@ fn test_storage_new_generic_fs() -> Result<()> {
         })
         .count();
 
-    watch!(n_storage_files_before);
-
     let push_result = x(&["file", "send", "--to", "generic-storage", the_file])?;
-    watch!(push_result);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -96,7 +89,6 @@ fn test_storage_new_generic_fs() -> Result<()> {
                 .unwrap_or_else(|_| false)
         })
         .count();
-    watch!(n_storage_files_after);
 
     assert!(
         n_storage_files_before + 1 == n_storage_files_after,
@@ -111,8 +103,6 @@ fn test_storage_new_generic_fs() -> Result<()> {
     sh(&format!("rm -rf {}", cache_dir.to_string_lossy()))?;
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "generic-storage"])?;
-
-    watch!(fetch_result);
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -130,7 +120,6 @@ fn test_storage_new_generic_fs() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "generic-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_generic_rsync.rs
+++ b/lib/tests/test_storage_new_generic_rsync.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 use common::*;
 use subprocess::Exec;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;
@@ -46,7 +46,7 @@ fn test_storage_new_generic_rsync() -> Result<()> {
         "ssh {url} 'test -e {storage_dir_name} && rm -rf {storage_dir_name}'"
     ));
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "generic",
@@ -78,7 +78,7 @@ fn test_storage_new_generic_rsync() -> Result<()> {
 
     let the_file = "file-0000.bin";
 
-    let file_track_result = x(&["file", "track", the_file])?;
+    x(&["file", "track", the_file])?;
 
     let n_storage_files_before = jwalk::WalkDir::new(local_test_dir)
         .into_iter()
@@ -126,7 +126,7 @@ fn test_storage_new_generic_rsync() -> Result<()> {
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
     fs::remove_file(the_file)?;
 
-    let pull_result = x(&["file", "bring", "--from", "generic-storage"])?;
+    x(&["file", "bring", "--from", "generic-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_generic_rsync.rs
+++ b/lib/tests/test_storage_new_generic_rsync.rs
@@ -24,7 +24,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -71,19 +70,15 @@ fn test_storage_new_generic_rsync() -> Result<()> {
         "4",
     ])?;
 
-    watch!(out);
-
     let storage_list = sh(format!(
         "ssh {url} 'ls -l {storage_dir_name}{XVC_STORAGE_GUID_FILENAME}'"
     ));
 
-    watch!(storage_list);
     assert!(!storage_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let n_storage_files_before = jwalk::WalkDir::new(local_test_dir)
         .into_iter()
@@ -94,10 +89,8 @@ fn test_storage_new_generic_rsync() -> Result<()> {
         })
         .count();
     let push_result = x(&["file", "send", "--to", "generic-storage", the_file])?;
-    watch!(push_result);
 
     let file_list = sh(format!("ssh {url} 'ls -1R {storage_dir_name} | grep bin'"));
-    watch!(file_list);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -118,8 +111,6 @@ fn test_storage_new_generic_rsync() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "generic-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -136,7 +127,6 @@ fn test_storage_new_generic_rsync() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "generic-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_local.rs
+++ b/lib/tests/test_storage_new_local.rs
@@ -4,7 +4,7 @@ use std::{fs, path::PathBuf};
 use log::LevelFilter;
 
 use common::*;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;
@@ -32,7 +32,7 @@ fn test_storage_new_local() -> Result<()> {
         common::run_xvc(Some(&xvc_root), cmd, XvcVerbosity::Trace)
     };
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "local",
@@ -46,7 +46,7 @@ fn test_storage_new_local() -> Result<()> {
 
     let the_file = "file-0000.bin";
 
-    let file_track_result = x(&["file", "track", the_file])?;
+    x(&["file", "track", the_file])?;
 
     let n_storage_files_before = jwalk::WalkDir::new(&storage_dir)
         .into_iter()
@@ -57,7 +57,7 @@ fn test_storage_new_local() -> Result<()> {
         })
         .count();
 
-    let push_result = x(&["file", "send", "--to", "local-storage", the_file])?;
+    x(&["file", "send", "--to", "local-storage", the_file])?;
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -86,7 +86,7 @@ fn test_storage_new_local() -> Result<()> {
         &cache_dir.to_string_lossy().to_string()
     ))?;
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "local-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "local-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -106,7 +106,7 @@ fn test_storage_new_local() -> Result<()> {
     ))?;
     fs::remove_file(the_file)?;
 
-    let bring_result = x(&["file", "bring", "--from", "local-storage"])?;
+    x(&["file", "bring", "--from", "local-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_minio.rs
+++ b/lib/tests/test_storage_new_minio.rs
@@ -42,7 +42,6 @@ fn mc_config(alias: &str, endpoint: &str, access_key: &str, secret_key: &str) ->
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -95,16 +94,12 @@ fn test_storage_new_minio() -> Result<()> {
         region,
     ])?;
 
-    watch!(out);
-
     let mc_bucket_list = mc("ls", &format!("| rg {bucket_name}"));
-    watch!(mc_bucket_list);
     assert!(!mc_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let n_storage_files_before = jwalk::WalkDir::new(local_test_dir)
         .into_iter()
@@ -115,10 +110,8 @@ fn test_storage_new_minio() -> Result<()> {
         })
         .count();
     let push_result = x(&["file", "send", "--to", "minio-storage", the_file])?;
-    watch!(push_result);
 
     let file_list = mc("ls -r ", &format!("| rg {bucket_name}/{storage_prefix}"));
-    watch!(file_list);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -141,12 +134,9 @@ fn test_storage_new_minio() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "minio-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
-            watch!(f);
             f.as_ref()
                 .map(|f| f.file_type().is_file())
                 .unwrap_or_else(|_| false)
@@ -166,7 +156,6 @@ fn test_storage_new_minio() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "minio-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -193,7 +182,6 @@ fn test_storage_new_minio() -> Result<()> {
     env::remove_var("MINIO_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "minio-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_r2.rs
+++ b/lib/tests/test_storage_new_r2.rs
@@ -126,7 +126,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -148,7 +147,6 @@ fn test_storage_new_r2() -> Result<()> {
     let account_id = account_id.trim();
 
     let config_file_name = write_s3cmd_config(account_id, access_key, secret_key)?;
-    watch!(config_file_name);
 
     let s3cmd = |cmd: &str, append: &str| -> String {
         let sh_cmd = format!("s3cmd --no-check-md5 --config {config_file_name} {cmd} {append}");
@@ -173,12 +171,10 @@ fn test_storage_new_r2() -> Result<()> {
         account_id,
     ])?;
 
-    watch!(out);
     let s3_bucket_list = s3cmd(
         &format!("ls --recursive 's3://{bucket_name}'"),
         &format!("| rg {storage_prefix} | rg {XVC_STORAGE_GUID_FILENAME}"),
     );
-    watch!(s3_bucket_list);
     assert!(!s3_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
@@ -191,16 +187,13 @@ fn test_storage_new_r2() -> Result<()> {
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_before);
     let n_storage_files_before = file_list_before.lines().count();
     let push_result = x(&["file", "send", "--to", "r2-storage", the_file])?;
-    watch!(push_result);
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_after);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -219,8 +212,6 @@ fn test_storage_new_r2() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "r2-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -237,7 +228,6 @@ fn test_storage_new_r2() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "r2-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -259,7 +249,6 @@ fn test_storage_new_r2() -> Result<()> {
     env::remove_var("R2_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "r2-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_rsync.rs
+++ b/lib/tests/test_storage_new_rsync.rs
@@ -24,7 +24,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -64,19 +63,15 @@ fn test_storage_new_rsync() -> Result<()> {
         &storage_dir_name,
     ])?;
 
-    watch!(out);
-
     let storage_list = sh(format!(
         "ssh {url} 'ls -l {storage_dir_name}{XVC_STORAGE_GUID_FILENAME}'"
     ));
 
-    watch!(storage_list);
     assert!(!storage_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let n_storage_files_before = jwalk::WalkDir::new(local_test_dir)
         .into_iter()
@@ -87,10 +82,8 @@ fn test_storage_new_rsync() -> Result<()> {
         })
         .count();
     let push_result = x(&["file", "send", "--to", "rsync-storage", the_file])?;
-    watch!(push_result);
 
     let file_list = sh(format!("ssh {url} 'ls -1R {storage_dir_name} | grep bin'"));
-    watch!(file_list);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -111,16 +104,11 @@ fn test_storage_new_rsync() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "rsync-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
             f.as_ref()
-                .map(|f| {
-                    watch!(f);
-                    f.file_type().is_file()
-                })
+                .map(|f| f.file_type().is_file())
                 .unwrap_or_else(|_| false)
         })
         .count();
@@ -132,7 +120,6 @@ fn test_storage_new_rsync() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "rsync-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_s3.rs
+++ b/lib/tests/test_storage_new_s3.rs
@@ -126,7 +126,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -143,7 +142,6 @@ fn test_storage_new_s3() -> Result<()> {
     let region = "eu-central-1";
 
     let config_file_name = write_s3cmd_config(region, &access_key, &secret_key)?;
-    watch!(config_file_name);
 
     let s3cmd = |cmd: &str, append: &str| -> String {
         let sh_cmd = format!("s3cmd --config {config_file_name} {cmd} {append}");
@@ -155,7 +153,6 @@ fn test_storage_new_s3() -> Result<()> {
     };
 
     let aws_create_bucket = s3cmd(&format!("mb s3://{bucket_name}"), "");
-    watch!(aws_create_bucket);
     //
     let out = x(&[
         "storage",
@@ -171,19 +168,15 @@ fn test_storage_new_s3() -> Result<()> {
         region,
     ])?;
 
-    watch!(out);
-
     let s3_bucket_list = s3cmd(
         &format!("ls --recursive 's3://{bucket_name}/'"),
         &format!(" | rg {storage_prefix} | rg {XVC_STORAGE_GUID_FILENAME}"),
     );
-    watch!(s3_bucket_list);
     assert!(!s3_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let cache_dir = xvc_root.xvc_dir().join("b3");
 
@@ -191,17 +184,13 @@ fn test_storage_new_s3() -> Result<()> {
         &format!("ls --recursive {bucket_name}"),
         &format!(" | rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_before);
     let n_storage_files_before = file_list_before.lines().count();
     let push_result = x(&["file", "send", "--to", "s3-storage", the_file])?;
-    watch!(push_result);
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-
-    watch!(file_list_after);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -220,8 +209,6 @@ fn test_storage_new_s3() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "s3-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -238,7 +225,6 @@ fn test_storage_new_s3() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "s3-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -260,7 +246,6 @@ fn test_storage_new_s3() -> Result<()> {
     env::remove_var("AWS_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "s3-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_wasabi.rs
+++ b/lib/tests/test_storage_new_wasabi.rs
@@ -128,7 +128,6 @@ fn create_directory_hierarchy() -> Result<XvcRoot> {
 }
 
 fn sh(cmd: String) -> String {
-    watch!(cmd);
     Exec::shell(cmd).capture().unwrap().stdout_str()
 }
 
@@ -145,7 +144,6 @@ fn test_storage_new_wasabi() -> Result<()> {
     let endpoint = "s3.wasabisys.com";
 
     let config_file_name = write_s3cmd_config(&access_key, &secret_key)?;
-    watch!(config_file_name);
 
     let s3cmd = |cmd: &str, append: &str| -> String {
         let sh_cmd = format!("s3cmd --config {config_file_name} {cmd} {append}");
@@ -170,18 +168,15 @@ fn test_storage_new_wasabi() -> Result<()> {
         endpoint,
     ])?;
 
-    watch!(out);
     let s3_bucket_list = s3cmd(
         &format!("ls --recursive 's3://{bucket_name}/'"),
         &format!("| rg {storage_prefix} | rg {XVC_STORAGE_GUID_FILENAME}"),
     );
-    watch!(s3_bucket_list);
     assert!(!s3_bucket_list.is_empty());
 
     let the_file = "file-0000.bin";
 
     let file_track_result = x(&["file", "track", the_file])?;
-    watch!(file_track_result);
 
     let cache_dir = xvc_root.xvc_dir().join("b3");
 
@@ -189,16 +184,13 @@ fn test_storage_new_wasabi() -> Result<()> {
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_before);
     let n_storage_files_before = file_list_before.lines().count();
     let push_result = x(&["file", "send", "--to", "wasabi-storage", the_file])?;
-    watch!(push_result);
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
-    watch!(file_list_after);
 
     // The file should be in:
     // - storage_dir/REPO_ID/b3/ABCD...123/0.bin
@@ -217,8 +209,6 @@ fn test_storage_new_wasabi() -> Result<()> {
 
     let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "wasabi-storage"])?;
 
-    watch!(fetch_result);
-
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
         .filter(|f| {
@@ -235,7 +225,6 @@ fn test_storage_new_wasabi() -> Result<()> {
     fs::remove_file(the_file)?;
 
     let pull_result = x(&["file", "bring", "--from", "wasabi-storage"])?;
-    watch!(pull_result);
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -256,7 +245,6 @@ fn test_storage_new_wasabi() -> Result<()> {
     env::remove_var("WASABI_SECRET_ACCESS_KEY");
 
     let pull_result_2 = x(&["file", "bring", "--from", "wasabi-storage"])?;
-    watch!(pull_result_2);
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_walker_parallel.rs
+++ b/lib/tests/test_walker_parallel.rs
@@ -10,7 +10,6 @@ use xvc_walker::*;
 use test_case::test_case;
 
 use xvc::error::Result;
-use xvc_logging::watch;
 use xvc_test_helper::*;
 use xvc_walker::AbsolutePath;
 

--- a/lib/tests/test_walker_parallel.rs
+++ b/lib/tests/test_walker_parallel.rs
@@ -46,7 +46,6 @@ fn new_dir_with_ignores(
 ) -> Result<IgnoreRules> {
     let patterns = create_patterns(root, dir, initial_patterns);
     let initialized = IgnoreRules::empty(&PathBuf::from(root), Some(".gitignore"));
-    watch!(patterns);
     initialized.add_patterns(patterns).unwrap();
     Ok(initialized)
 }
@@ -68,8 +67,6 @@ fn create_patterns(root: &str, dir: Option<&str>, patterns: &str) -> Vec<Pattern
 #[test_case("", "*.bin\n!dir-0002/*" => it contains "dir-0002/file-0001.bin" ; "t3572817176" )]
 #[test_case("", "*.bin\n!dir-0002/**" => it contains "dir-0002/file-0001.bin" ; "t7772817176" )]
 fn test_walk_parallel(ignore_src: &str, ignore_content: &str) -> Vec<String> {
-    watch!(ignore_src);
-    watch!(ignore_content);
     test_logging(LevelFilter::Trace);
     let root = create_directory_hierarchy(true).unwrap();
     let (path_sender, path_receiver) = crossbeam_channel::unbounded();
@@ -100,6 +97,5 @@ fn test_walk_parallel(ignore_src: &str, ignore_content: &str) -> Vec<String> {
             Err(_) => None,
         })
         .collect();
-    watch!(paths);
     paths
 }

--- a/lib/tests/test_walker_serial.rs
+++ b/lib/tests/test_walker_serial.rs
@@ -63,10 +63,6 @@ fn test_walk_serial(ignore_src: &str, ignore_content: &str) -> Vec<String> {
     };
     let (output_sender, output_receiver) = crossbeam_channel::unbounded();
     let (res_paths, ignore_rules) = walk_serial(&output_sender, "", &root, &walk_options).unwrap();
-    watch!(ignore_rules.ignore_patterns.read().unwrap());
-    watch!(ignore_rules.whitelist_patterns.read().unwrap());
-    watch!(output_receiver);
-    watch!(res_paths);
     fs::remove_dir_all(&root).unwrap();
     let out_paths = res_paths
         .iter()
@@ -76,6 +72,5 @@ fn test_walk_serial(ignore_src: &str, ignore_content: &str) -> Vec<String> {
             p.strip_prefix(&root.to_string()).unwrap_or(&p).to_owned()
         })
         .collect();
-    watch!(out_paths);
     out_paths
 }

--- a/lib/tests/z_test_docs.rs
+++ b/lib/tests/z_test_docs.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use regex::Regex;
 
 use xvc::error::Result;
-use xvc_logging::{info, warn, watch};
+use xvc_logging::{info, warn};
 use xvc_test_helper::{make_symlink, random_temp_dir, test_logging};
 
 use fs_extra::{self, dir::CopyOptions};
@@ -188,13 +188,11 @@ fn make_output_dir_link(
     let source = templates_root.join(&dirname);
     if !source.exists() {
         let target = docs_target_dir.join(&dirname);
-        if target.exists() {
-            if target.read_link().unwrap() == source {
-                fs::remove_file(&target).unwrap_or_else(|e| {
-                    info!("Failed to remove file: {}", e);
-                    exit(1);
-                });
-            }
+        if target.exists() && target.read_link().unwrap() == source {
+            fs::remove_file(&target).unwrap_or_else(|e| {
+                info!("Failed to remove file: {}", e);
+                exit(1);
+            });
         }
         match make_symlink(&source, &target) {
             Ok(_) => (),

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -11,11 +11,11 @@ use std::fmt::Display;
 use std::path::Path;
 use std::sync::Once;
 
-
 /// Debugging macro to print the given expression and its value, with the module, function and line number
 #[macro_export]
 macro_rules! watch {
     ( $( $x:expr ),* ) => {
+        // TODO: Use stdout for this and convert all tracing macros to trace!
         {
             $(
                ::log::trace!("{}: {}", stringify!($x), format!("{:#?}", $x).replace("\\n", "\n"));
@@ -98,6 +98,14 @@ macro_rules! trace {
     ( $channel:expr, $fmt:literal $(, $x:expr ),* ) => {
         {
             (&$channel).send(Some(::xvc_logging::XvcOutputLine::Trace(format!("{} [{}::{}]", format!($fmt $(, $x)*), file!(), line!())))).unwrap();
+        }
+    };
+
+    ( $( $x:expr ),* ) => {
+        {
+            $(
+               ::log::trace!("{}: {}", stringify!($x), format!("{:#?}", $x).replace("\\n", "\n"));
+            )*
         }
     };
 }

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -19,12 +19,12 @@ default = []
 bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
-xvc-file = { version = "0.6.13-alpha.2", path = "../file", default-features = false }
+xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-file = { version = "0.6.13-alpha.3", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -99,5 +99,5 @@ itertools = "^0.13"
 derive_more = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
 test-case = "^3.3"

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -19,12 +19,12 @@ default = []
 bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
-xvc-file = { version = "0.6.13-alpha.4", path = "../file", default-features = false }
+xvc-config = { version = "0.6.13-alpha.5", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.5", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.5", path = "../ecs" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
+xvc-file = { version = "0.6.13-alpha.5", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -99,5 +99,5 @@ itertools = "^0.13"
 derive_more = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.5", path = "../test_helper/" }
 test-case = "^3.3"

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -19,12 +19,12 @@ default = []
 bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
-xvc-file = { version = "0.6.13-alpha.3", path = "../file", default-features = false }
+xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-file = { version = "0.6.13-alpha.4", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -99,5 +99,5 @@ itertools = "^0.13"
 derive_more = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
 test-case = "^3.3"

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -19,12 +19,12 @@ default = []
 bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
-xvc-config = { version = "0.6.13-alpha.1", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.1", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.1", path = "../ecs" }
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
-xvc-file = { version = "0.6.13-alpha.1", path = "../file", default-features = false }
+xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-file = { version = "0.6.13-alpha.2", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -99,5 +99,5 @@ itertools = "^0.13"
 derive_more = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.1", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
 test-case = "^3.3"

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -6,7 +6,7 @@ use tabbycat::{AttrList, Edge, GraphBuilder, Identity, StmtList};
 use xvc_config::FromConfigKey;
 use xvc_core::{XvcPath, XvcPathMetadataProvider, XvcRoot};
 use xvc_ecs::{HStore, R1NStore, XvcEntity};
-use xvc_logging::{info, output, watch, XvcOutputSender};
+use xvc_logging::{info, output, XvcOutputSender};
 
 use std::collections::HashMap;
 use std::{fs::File, io::Write};

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -155,7 +155,9 @@ fn dep_identity(dep: &XvcDependency) -> Result<Identity> {
             id_from_string(&format!("{}::{}-{}", dep.path, dep.begin, dep.end))
         }
         XvcDependency::UrlDigest(dep) => id_from_string(dep.url.as_ref()),
-        XvcDependency::SqliteQueryDigest(dep) => id_from_string(&format!("{} {}", dep.path, dep.query)),
+        XvcDependency::SqliteQueryDigest(dep) => {
+            id_from_string(&format!("{} {}", dep.path, dep.query))
+        }
     }
 }
 
@@ -339,4 +341,3 @@ fn make_mermaid_graph(
 
     Ok(res_string)
 }
-

--- a/pipeline/src/pipeline/api/step_dependency.rs
+++ b/pipeline/src/pipeline/api/step_dependency.rs
@@ -18,7 +18,7 @@ use regex::Regex;
 use url::Url;
 use xvc_core::{XvcPath, XvcRoot};
 use xvc_ecs::{R1NStore, XvcEntity};
-use xvc_logging::{debug, watch, XvcOutputSender};
+use xvc_logging::{debug, XvcOutputSender};
 use xvc_walker::AbsolutePath;
 
 use crate::{pipeline::deps, XvcDependency, XvcParamFormat, XvcPipeline, XvcStep};

--- a/pipeline/src/pipeline/api/step_dependency.rs
+++ b/pipeline/src/pipeline/api/step_dependency.rs
@@ -222,14 +222,13 @@ impl<'a> XvcDependencyList<'a> {
                         return Err(Error::InvalidRegexFormat { regex });
                     }
                 };
-                watch!(captures);
+
                 let regex_file = match captures.name("regex_file") {
                     Some(regex_file) => regex_file.as_str(),
                     None => {
                         return Err(Error::InvalidRegexFormat { regex });
                     }
                 };
-                watch!(regex_file);
 
                 let regex_str = match captures.name("regex") {
                     Some(regex_str) => regex_str.as_str().to_string(),
@@ -237,7 +236,6 @@ impl<'a> XvcDependencyList<'a> {
                         return Err(Error::InvalidRegexFormat { regex });
                     }
                 };
-                watch!(regex_str);
 
                 // Check if the supplied regexp is well formed
                 if Regex::new(&regex_str).is_err() {
@@ -384,7 +382,6 @@ impl<'a> XvcDependencyList<'a> {
     }
 
     pub fn sqlite_query(&mut self, sqlite_query: Option<Vec<String>>) -> Result<&mut Self> {
-
         if let Some(sqlite_query) = sqlite_query {
             let mut deps = self.deps.borrow_mut();
             let path = sqlite_query[0].clone();
@@ -393,7 +390,7 @@ impl<'a> XvcDependencyList<'a> {
             let xvc_path = XvcPath::new(self.xvc_root, self.current_dir, &pathbuf)?;
             let sqlite_query = sqlite_query::SqliteQueryDep::new(xvc_path, query);
             deps.push(XvcDependency::SqliteQueryDigest(sqlite_query));
-         }
+        }
         Ok(self)
     }
     /// Records dependencies the store, as children of `self.step`.
@@ -416,4 +413,3 @@ impl<'a> XvcDependencyList<'a> {
         Ok(())
     }
 }
-

--- a/pipeline/src/pipeline/api/step_list.rs
+++ b/pipeline/src/pipeline/api/step_list.rs
@@ -17,7 +17,6 @@ pub fn cmd_step_list(
     xvc_root
         .with_r1nstore(|rs: &R1NStore<XvcPipeline, XvcStep>| {
             let steps: HStore<XvcStep> = rs.children_of(&pipeline_e)?;
-            watch!(steps);
 
             if names_only {
                 for (_, step) in steps.into_iter().sorted() {

--- a/pipeline/src/pipeline/api/step_list.rs
+++ b/pipeline/src/pipeline/api/step_list.rs
@@ -4,7 +4,7 @@ use crate::{
 use itertools::Itertools;
 use xvc_core::XvcRoot;
 use xvc_ecs::{HStore, R1NStore};
-use xvc_logging::{output, watch, XvcOutputSender};
+use xvc_logging::{output, XvcOutputSender};
 
 pub fn cmd_step_list(
     output_snd: &XvcOutputSender,

--- a/pipeline/src/pipeline/command.rs
+++ b/pipeline/src/pipeline/command.rs
@@ -84,16 +84,13 @@ impl CommandProcess {
 
     /// Add an environment variable to inject to the shell that runs the command.
     pub fn add_environment_variable(&mut self, key: &str, value: &str) -> Result<&mut Self> {
-        watch!(self);
         self.environment.insert(key.to_owned(), value.to_owned());
-        watch!(self);
         Ok(self)
     }
 
     /// Start executing the command in a shell. Updates birth and process variables after
     /// detaching.
     pub fn run(&mut self) -> Result<()> {
-        watch!(self.environment);
         let process = sp::Exec::shell(self.step_command.command.clone())
             .stdout(sp::Redirection::Pipe)
             .stderr(sp::Redirection::Pipe)

--- a/pipeline/src/pipeline/command.rs
+++ b/pipeline/src/pipeline/command.rs
@@ -10,7 +10,6 @@ use std::time::Instant;
 use subprocess as sp;
 
 use xvc_file::CHANNEL_CAPACITY;
-use xvc_logging::watch;
 
 use serde::{Deserialize, Serialize};
 use xvc_ecs::persist;

--- a/pipeline/src/pipeline/deps/generic.rs
+++ b/pipeline/src/pipeline/deps/generic.rs
@@ -37,14 +37,10 @@ impl GenericDep {
     /// Run the command and update the output digest
     pub fn update_output_digest(self) -> Result<Self> {
         let generic_command = self.generic_command;
-        watch!(generic_command);
 
         let command_output = Exec::shell(generic_command.clone()).capture()?;
-        watch!(command_output);
         let stdout = String::from_utf8(command_output.stdout)?;
         let stderr = String::from_utf8(command_output.stderr)?;
-        watch!(stdout);
-        watch!(stderr);
         let algorithm = HashAlgorithm::Blake3;
         let return_code = command_output.exit_status;
         if !stderr.is_empty() || !return_code.success() {
@@ -69,8 +65,6 @@ impl Diffable for GenericDep {
     /// Compare the command and the output.
     /// WARN: Self::update_output_digest() must be called before this method.
     fn diff_thorough(record: &Self::Item, actual: &Self::Item) -> Diff<Self::Item> {
-        watch!(record);
-        watch!(actual);
         if record == actual {
             Diff::Identical
         } else {

--- a/pipeline/src/pipeline/deps/glob.rs
+++ b/pipeline/src/pipeline/deps/glob.rs
@@ -134,20 +134,15 @@ impl Diffable for GlobDep {
 
     fn diff_superficial(record: &Self::Item, actual: &Self::Item) -> xvc_core::Diff<Self::Item> {
         assert!(record.glob == actual.glob);
-        watch!(record);
-        watch!(actual);
         let path_collection_diff = PathCollectionDigest::diff(
             record.xvc_paths_digest.as_ref(),
             actual.xvc_paths_digest.as_ref(),
         );
-        watch!(path_collection_diff);
         let path_collection_metadata_diff = PathCollectionMetadataDigest::diff(
             record.xvc_metadata_digest.as_ref(),
             actual.xvc_metadata_digest.as_ref(),
         );
-        watch!(path_collection_metadata_diff);
         if path_collection_diff.changed() || path_collection_metadata_diff.changed() {
-            watch!("Different");
             Diff::Different {
                 record: record.clone(),
                 actual: actual.clone(),

--- a/pipeline/src/pipeline/deps/param.rs
+++ b/pipeline/src/pipeline/deps/param.rs
@@ -79,8 +79,6 @@ impl Diffable for ParamDep {
     /// ⚠️ Call actual.update_metadata before calling this function ⚠️
     fn diff_superficial(record: &Self::Item, actual: &Self::Item) -> Diff<Self::Item> {
         assert!(record.path == actual.path);
-        watch!(record);
-        watch!(actual);
         match (record.xvc_metadata, actual.xvc_metadata) {
             (Some(record_md), Some(actual_md)) => {
                 if record_md == actual_md {
@@ -105,8 +103,6 @@ impl Diffable for ParamDep {
     /// ⚠️ Call actual.update_metadata and actual.update_value before calling this function ⚠️
     fn diff_thorough(record: &Self::Item, actual: &Self::Item) -> Diff<Self::Item> {
         assert!(record.path == actual.path);
-        watch!(record);
-        watch!(actual);
         match Self::diff_superficial(record, actual) {
             Diff::Identical => Diff::Identical,
             Diff::Different { .. } => {
@@ -272,11 +268,10 @@ impl XvcParamValue {
     /// Loads the key (in the form of a.b.c) from a YAML document
     fn parse_yaml(all_content: &str, key: &str) -> Result<XvcParamValue> {
         let yaml_map: YamlValue = serde_yaml::from_str(all_content)?;
-        watch!(yaml_map);
+
         let nested_keys: Vec<&str> = key.split('.').collect();
         let mut current_scope: YamlValue = yaml_map;
         for k in &nested_keys {
-            watch!(k);
             if let Some(current_value) = current_scope.get(*k) {
                 match current_value {
                     YamlValue::Mapping(_) => {

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -1,3 +1,4 @@
-LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc --test z_test_docs
+# LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc # --test z_test_docs
+XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo test --features test-ci -p xvc 
 
 # cargo test --features test-ci -p xvc --test test_storage_new_minio

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -1,3 +1,3 @@
-LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc # --test z_test_docs
+# LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc # --test z_test_docs
 # XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite rws cargo test --features test-ci -p xvc 
 

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -1,4 +1,3 @@
-# LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc # --test z_test_docs
-XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo test --features test-ci -p xvc 
+LLVM_PROFILE_FILE="${TMPDIR}/xvc-%p-%m.profraw" CARGO_INCREMENTAL=0 RUSTFLAGS="-Cinstrument-coverage" XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo llvm-cov --features test-ci --lcov --output-path lcov.info -p xvc # --test z_test_docs
+# XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite rws cargo test --features test-ci -p xvc 
 
-# cargo test --features test-ci -p xvc --test test_storage_new_minio

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.1", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.1", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.1", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.1", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -105,7 +105,7 @@ bundled-openssl = ["openssl/vendored"]
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.1", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
 shellfn = "^0.1"
 
 [package.metadata.cargo-udeps.ignore]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -105,7 +105,7 @@ bundled-openssl = ["openssl/vendored"]
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
 shellfn = "^0.1"
 
 [package.metadata.cargo-udeps.ignore]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.2", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.2", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.2", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.2", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.3", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.3", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.3", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.3", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -105,7 +105,7 @@ bundled-openssl = ["openssl/vendored"]
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.2", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.3", path = "../test_helper/" }
 shellfn = "^0.1"
 
 [package.metadata.cargo-udeps.ignore]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
-xvc-config = { version = "0.6.13-alpha.4", path = "../config" }
-xvc-core = { version = "0.6.13-alpha.4", path = "../core" }
-xvc-ecs = { version = "0.6.13-alpha.4", path = "../ecs" }
-xvc-walker = { version = "0.6.13-alpha.4", path = "../walker" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
+xvc-config = { version = "0.6.13-alpha.5", path = "../config" }
+xvc-core = { version = "0.6.13-alpha.5", path = "../core" }
+xvc-ecs = { version = "0.6.13-alpha.5", path = "../ecs" }
+xvc-walker = { version = "0.6.13-alpha.5", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -105,7 +105,7 @@ bundled-openssl = ["openssl/vendored"]
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.6.13-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.6.13-alpha.5", path = "../test_helper/" }
 shellfn = "^0.1"
 
 [package.metadata.cargo-udeps.ignore]

--- a/storage/src/storage/async_common.rs
+++ b/storage/src/storage/async_common.rs
@@ -158,13 +158,10 @@ pub(crate) trait XvcS3StorageOperations {
         let bucket = self.get_bucket()?;
 
         for cache_path in paths {
-            watch!(cache_path);
             let storage_path = self.build_storage_path(cache_path);
             let abs_cache_path = cache_path.to_absolute_path(xvc_root);
-            watch!(abs_cache_path);
 
             let mut path = tokio::fs::File::open(&abs_cache_path).await?;
-            watch!(path);
 
             let res_response = bucket
                 .put_object_stream(&mut path, storage_path.as_str())
@@ -179,7 +176,6 @@ pub(crate) trait XvcS3StorageOperations {
                         storage_path.as_str()
                     );
                     copied_paths.push(storage_path);
-                    watch!(copied_paths.len());
                 }
                 Err(err) => {
                     error!(output_snd, "{}", err);
@@ -206,12 +202,10 @@ pub(crate) trait XvcS3StorageOperations {
         let temp_dir = XvcStorageTempDir::new()?;
 
         for cache_path in paths {
-            watch!(cache_path);
             let storage_path = self.build_storage_path(cache_path);
             let abs_cache_dir = temp_dir.temp_cache_dir(cache_path)?;
             fs::create_dir_all(&abs_cache_dir)?;
             let abs_cache_path = temp_dir.temp_cache_path(cache_path)?;
-            watch!(abs_cache_path);
             let response_data_stream = bucket.get_object_stream(storage_path.as_str()).await;
 
             match response_data_stream {
@@ -227,7 +221,6 @@ pub(crate) trait XvcS3StorageOperations {
                         async_cache_path.write_all(&chunk?).await?;
                     }
                     copied_paths.push(storage_path);
-                    watch!(copied_paths.len());
                 }
                 Err(err) => {
                     error!(output_snd, "{}", err);
@@ -255,7 +248,6 @@ pub(crate) trait XvcS3StorageOperations {
         let bucket = self.get_bucket()?;
 
         for cache_path in paths {
-            watch!(cache_path);
             let storage_path = self.build_storage_path(cache_path);
             bucket.delete_object(storage_path.as_str()).await?;
             info!(output, "[DELETE] {}", storage_path.as_str());
@@ -309,7 +301,6 @@ impl<T: XvcS3StorageOperations> XvcStorageOperations for T {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()?;
-        watch!(rt);
         rt.block_on(self.a_init(output))
     }
 

--- a/storage/src/storage/digital_ocean.rs
+++ b/storage/src/storage/digital_ocean.rs
@@ -38,10 +38,8 @@ pub fn cmd_new_digital_ocean(
         bucket_name,
         storage_prefix,
     };
-    watch!(storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
-    watch!(init_event);
 
     xvc_root.with_r1nstore_mut(|store: &mut R1NStore<XvcStorage, XvcStorageEvent>| {
         let store_e = xvc_root.new_entity();

--- a/storage/src/storage/gcs.rs
+++ b/storage/src/storage/gcs.rs
@@ -5,7 +5,7 @@ use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_ecs::R1NStore;
-use xvc_logging::{watch, XvcOutputSender};
+use xvc_logging::{info, watch, XvcOutputSender};
 
 use anyhow::anyhow;
 
@@ -39,7 +39,7 @@ pub fn cmd_new_gcs(
         storage_prefix,
     };
 
-    watch!(storage);
+    info!(output_snd, "New Storage: {:#?}", storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
     watch!(init_event);

--- a/storage/src/storage/generic.rs
+++ b/storage/src/storage/generic.rs
@@ -222,16 +222,12 @@ impl XvcGenericStorage {
         // TODO: Refactor to use XvcStoragePath and XvcCachePath in replacements
         paths.iter().for_each(|cache_path| {
             let pm = self.path_map_with_temp_dir(xvc_root, temp_dir, cache_path);
-            watch!(pm);
             let cmd = Self::replace_map_elements(prepared_cmd, &pm);
-            watch!(cmd);
             let cmd_output = Exec::shell(cmd).capture();
             match cmd_output {
                 Ok(cmd_output) => {
                     let stdout_str = cmd_output.stdout_str();
                     let stderr_str = cmd_output.stderr_str();
-                    watch!(stdout_str);
-                    watch!(stderr_str);
 
                     if cmd_output.success() {
                         info!(output_snd, "{}", stdout_str);
@@ -264,16 +260,12 @@ impl XvcGenericStorage {
         // TODO: Refactor to use XvcStoragePath and XvcCachePath in replacements
         paths.iter().for_each(|cache_path| {
             let pm = self.path_map(xvc_root, cache_path);
-            watch!(pm);
             let cmd = Self::replace_map_elements(prepared_cmd, &pm);
-            watch!(cmd);
             let cmd_output = Exec::shell(cmd).capture();
             match cmd_output {
                 Ok(cmd_output) => {
                     let stdout_str = cmd_output.stdout_str();
                     let stderr_str = cmd_output.stderr_str();
-                    watch!(stdout_str);
-                    watch!(stderr_str);
 
                     if cmd_output.success() {
                         info!(output, "{}", stdout_str);
@@ -307,9 +299,7 @@ impl XvcStorageOperations for XvcGenericStorage {
         _xvc_root: &XvcRoot,
     ) -> Result<super::XvcStorageInitEvent> {
         let mut address_map = self.address_map();
-        watch!(address_map);
         let local_guid_path = env::temp_dir().join(self.guid.to_string());
-        watch!(local_guid_path);
 
         fs::write(&local_guid_path, format!("{}", self.guid))?;
 
@@ -326,12 +316,9 @@ impl XvcStorageOperations for XvcGenericStorage {
         address_map.insert("{STORAGE_GUID_FILE_PATH}", storage_guid_file_path);
 
         let prepared_init_cmd = Self::replace_map_elements(&self.init_command, &address_map);
-        watch!(prepared_init_cmd);
         let init_output = Exec::shell(prepared_init_cmd.clone())
             .capture()?
             .stdout_str();
-
-        watch!(init_output);
 
         info!(
             output,
@@ -390,11 +377,8 @@ impl XvcStorageOperations for XvcGenericStorage {
         _force: bool,
     ) -> Result<XvcStorageSendEvent> {
         let address_map = self.address_map();
-        watch!(address_map);
         let prepared_cmd = Self::replace_map_elements(&self.upload_command, &address_map);
-        watch!(prepared_cmd);
         let storage_paths = self.run_for_paths(output, xvc_root, &prepared_cmd, paths);
-        watch!(storage_paths);
 
         Ok(XvcStorageSendEvent {
             guid: self.guid.clone(),
@@ -410,13 +394,10 @@ impl XvcStorageOperations for XvcGenericStorage {
         _force: bool,
     ) -> Result<(XvcStorageTempDir, XvcStorageReceiveEvent)> {
         let address_map = self.address_map();
-        watch!(address_map);
         let temp_dir = XvcStorageTempDir::new()?;
         let prepared_cmd = Self::replace_map_elements(&self.download_command, &address_map);
-        watch!(prepared_cmd);
         let storage_paths =
             self.run_for_paths_in_temp_dir(output, xvc_root, &prepared_cmd, &temp_dir, paths);
-        watch!(storage_paths);
 
         Ok((
             temp_dir,

--- a/storage/src/storage/generic.rs
+++ b/storage/src/storage/generic.rs
@@ -47,7 +47,7 @@ pub fn cmd_storage_new_generic(
         max_processes,
     };
 
-    watch!(storage);
+    info!(output_snd, "Generic Storage: {:#?}", storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
 

--- a/storage/src/storage/local.rs
+++ b/storage/src/storage/local.rs
@@ -73,7 +73,6 @@ impl XvcStorageOperations for XvcLocalStorage {
     ) -> Result<XvcStorageInitEvent> {
         let guid_filename = self.path.join(XVC_STORAGE_GUID_FILENAME);
         // If guid filename exists, we can report a reinit and exit.
-        watch!(guid_filename);
 
         if guid_filename.exists() {
             let already_available_guid =
@@ -139,7 +138,6 @@ impl XvcStorageOperations for XvcLocalStorage {
             fs::create_dir_all(abs_storage_dir)?;
             fs::copy(&abs_cache_path, &abs_storage_path)?;
             copied_paths.push(storage_path);
-            watch!(copied_paths.len());
             info!(
                 output,
                 "{} -> {}",
@@ -175,9 +173,7 @@ impl XvcStorageOperations for XvcLocalStorage {
             let abs_cache_dir = temp_dir.temp_cache_dir(cache_path)?;
             fs::create_dir_all(&abs_cache_dir)?;
             fs::copy(&abs_storage_path, &abs_cache_path)?;
-            watch!(abs_cache_path.exists());
             copied_paths.push(storage_path);
-            watch!(copied_paths.len());
             info!(
                 output,
                 "{} -> {}",

--- a/storage/src/storage/minio.rs
+++ b/storage/src/storage/minio.rs
@@ -44,10 +44,8 @@ pub fn cmd_new_minio(
         storage_prefix,
         endpoint,
     };
-    watch!(storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
-    watch!(init_event);
 
     xvc_root.with_r1nstore_mut(|store: &mut R1NStore<XvcStorage, XvcStorageEvent>| {
         let store_e = xvc_root.new_entity();

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -269,7 +269,6 @@ impl XvcStorageOperations for XvcStorage {
         paths: &[XvcCachePath],
         force: bool,
     ) -> Result<(XvcStorageTempDir, XvcStorageReceiveEvent)> {
-        watch!(paths);
         match self {
             XvcStorage::Local(lr) => lr.receive(output, xvc_root, paths, force),
             XvcStorage::Generic(gr) => gr.receive(output, xvc_root, paths, force),

--- a/storage/src/storage/r2.rs
+++ b/storage/src/storage/r2.rs
@@ -45,7 +45,6 @@ pub fn cmd_new_r2(
     info!(output_snd, "R2 Storage: {:#?}", storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
-    watch!(init_event);
 
     xvc_root.with_r1nstore_mut(|store: &mut R1NStore<XvcStorage, XvcStorageEvent>| {
         let store_e = xvc_root.new_entity();

--- a/storage/src/storage/r2.rs
+++ b/storage/src/storage/r2.rs
@@ -8,7 +8,7 @@ use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::{XvcCachePath, XvcRoot};
 use xvc_ecs::R1NStore;
-use xvc_logging::{error, watch, XvcOutputSender};
+use xvc_logging::{error, info, watch, XvcOutputSender};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};
@@ -42,7 +42,7 @@ pub fn cmd_new_r2(
         storage_prefix,
     };
 
-    watch!(storage);
+    info!(output_snd, "R2 Storage: {:#?}", storage);
 
     let init_event = storage.init(output_snd, xvc_root)?;
     watch!(init_event);

--- a/storage/src/storage/rsync.rs
+++ b/storage/src/storage/rsync.rs
@@ -398,8 +398,6 @@ impl XvcStorageOperations for XvcRsyncStorage {
                 Ok(cmd_output) => {
                     let stdout_str = cmd_output.stdout_str();
                     let stderr_str = cmd_output.stderr_str();
-                    watch!(stdout_str);
-                    watch!(stderr_str);
                     info!(output, "{}", stdout_str);
                     warn!(output, "{}", stderr_str);
                     let storage_path = XvcStoragePath::new(xvc_root, cache_path);

--- a/storage/src/storage/s3.rs
+++ b/storage/src/storage/s3.rs
@@ -56,7 +56,7 @@ pub fn cmd_new_s3(
         Ok(())
     })?;
 
-    info!(output_snd, "S3 Storage Created: {#:?}", storage);
+    info!(output_snd, "S3 Storage Created: {:#?}", storage);
 
     Ok(())
 }

--- a/storage/src/storage/s3.rs
+++ b/storage/src/storage/s3.rs
@@ -8,7 +8,7 @@ use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::{XvcCachePath, XvcRoot};
 use xvc_ecs::R1NStore;
-use xvc_logging::{watch, XvcOutputSender};
+use xvc_logging::{info, watch, XvcOutputSender};
 
 use crate::storage::XVC_STORAGE_GUID_FILENAME;
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
@@ -41,8 +41,6 @@ pub fn cmd_new_s3(
         storage_prefix,
     };
 
-    watch!(storage);
-
     let init_event = storage.init(output_snd, xvc_root)?;
     watch!(init_event);
 
@@ -57,6 +55,8 @@ pub fn cmd_new_s3(
         );
         Ok(())
     })?;
+
+    info!(output_snd, "S3 Storage Created: {#:?}", storage);
 
     Ok(())
 }

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Unit test helper functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging/" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging/" }
 
 rand = "^0.8"
 log = "^0.4"

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Unit test helper functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging/" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging/" }
 
 rand = "^0.8"
 log = "^0.4"

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Unit test helper functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging/" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging/" }
 
 rand = "^0.8"
 log = "^0.4"

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Unit test helper functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging/" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging/" }
 
 rand = "^0.8"
 log = "^0.4"

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.6.13-alpha.2"
+version = "0.6.13-alpha.3"
 edition = "2021"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
 # NOTE: 0.4 removes Glob struct and this should be handled with care
 fast-glob = "^0.3"
 
@@ -42,7 +42,7 @@ itertools = "^0.13"
 regex = "^1.10"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.2" }
+xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.3" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.6.13-alpha.4"
+version = "0.6.13-alpha.5"
 edition = "2021"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.5", path = "../logging" }
 # NOTE: 0.4 removes Glob struct and this should be handled with care
 fast-glob = "^0.3"
 
@@ -42,7 +42,7 @@ itertools = "^0.13"
 regex = "^1.10"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.4" }
+xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.5" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.6.13-alpha.1"
+version = "0.6.13-alpha.2"
 edition = "2021"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.1", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.2", path = "../logging" }
 # NOTE: 0.4 removes Glob struct and this should be handled with care
 fast-glob = "^0.3"
 
@@ -42,7 +42,7 @@ itertools = "^0.13"
 regex = "^1.10"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.1" }
+xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.2" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.6.13-alpha.3"
+version = "0.6.13-alpha.4"
 edition = "2021"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.6.13-alpha.3", path = "../logging" }
+xvc-logging = { version = "0.6.13-alpha.4", path = "../logging" }
 # NOTE: 0.4 removes Glob struct and this should be handled with care
 fast-glob = "^0.3"
 
@@ -42,7 +42,7 @@ itertools = "^0.13"
 regex = "^1.10"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.3" }
+xvc-test-helper = { path = "../test_helper/", version = "0.6.13-alpha.4" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added new build targets to GitHub Actions workflow for Linux and macOS in `rust.yml`.
> 
>   - **GitHub Actions**:
>     - Added `aarch64-unknown-linux-gnu` to Linux targets in `rust.yml`.
>     - Added `aarch64-apple-darwin` and `x86_64-unknown-freebsd` to macOS targets in `rust.yml`.
>   - **Changelog**:
>     - Updated `CHANGELOG.md` to note the addition of more targets to GitHub builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=iesahin%2Fxvc&utm_source=github&utm_medium=referral)<sup> for f7570ca56f19b07f128f8b20cd77da0afcbf2cd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces new build targets for GitHub Actions, updates the changelog, and modifies various files to reflect version changes.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Build as Build Process
    participant Release as Release Process
    participant Platforms as Multiple Platforms

    GH->>Build: Trigger on v*.*.* tags
    Build->>Release: Start release workflow
    
    Release->>Platforms: Build for multiple targets
    Note over Platforms: FreeBSD x86_64<br/>Linux x86_64/aarch64<br/>Windows x86_64/aarch64<br/>macOS x86_64/aarch64
    
    loop For each platform
        Platforms->>Build: Build with platform-specific features
        Note over Build: bundled-openssl<br/>bundled-sqlite
        Build->>Release: Generate artifacts
    end
    
    Release->>GH: Publish release artifacts
    Note over Release: Use houseabsolute/actions-rust-cross
    Note over Release: Use houseabsolute/actions-rust-release
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34>.github/workflows/release.yml</a></td><td>Added a new GitHub Actions workflow for releases with multiple OS targets.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d>.github/workflows/rust.yml</a></td><td>Commented out old deployment jobs for Linux, Windows, and macOS.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed>CHANGELOG.md</a></td><td>Updated changelog to reflect new features and fixes.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-94a96a58cd6a12becb0256bcdff442ed1935f359a4a642ceae321df5a1e07632>config/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-ac4e3071598a47848866c532150a233af5159d2757dab53572781ed09e13fbee>core/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-d30870e14ef35a16e923d889ea12b34e34b89b8530aa6f48baca762b9e7c036f>file/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-fac5fcf0ea8031f2c9c7f88852c186b2dba12657d9c8c1a3dca4ffbad12602af>lib/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-1bc5295720b3cef85cb02ee50bf34162eeabbbbac323d766e7faa38599da5d57>storage/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/263/files#diff-9220d0e383f5e8636ad2c065d32e61bca212e8c9e0c39497ab1a1c8447430436>walker/Cargo.toml</a></td><td>Updated version to 0.6.13-alpha.5.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.yml`, `.md`, `.toml`, `.zsh`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




















































