### PR TITLE
xvc storage remove

### DIFF
--- a/book/src/ref/xvc-file-remove.md
+++ b/book/src/ref/xvc-file-remove.md
@@ -93,10 +93,6 @@ You can remove the file from the cache. The file is still tracked by Xvc and ava
 ```console
 $ xvc file remove --from-cache data.txt
 [DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt
-[DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496
-[DELETE] [CWD]/.xvc/b3/c85/f3e
-[DELETE] [CWD]/.xvc/b3/c85
-[DELETE] [CWD]/.xvc/b3
 
 $ ls
 data.txt
@@ -161,9 +157,6 @@ Total #: 1 Workspace Size:          19 Cached Size:          19
 
 $ xvc file remove --from-cache --only-version c85-f3e data.txt
 [DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt
-[DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496
-[DELETE] [CWD]/.xvc/b3/c85/f3e
-[DELETE] [CWD]/.xvc/b3/c85
 
 $ tree .xvc/b3/
 .xvc/b3/
@@ -208,18 +201,8 @@ $ tree .xvc/b3/
 
 $ xvc file remove --from-cache --all-versions data.txt
 [DELETE] [CWD]/.xvc/b3/017/ad8/6d31011a7f6c8eabd808ba4f8cf3d3c0c65322ded3fffdfcb8d60279a0/0.txt
-[DELETE] [CWD]/.xvc/b3/017/ad8/6d31011a7f6c8eabd808ba4f8cf3d3c0c65322ded3fffdfcb8d60279a0
-[DELETE] [CWD]/.xvc/b3/017/ad8
-[DELETE] [CWD]/.xvc/b3/017
 [DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367/0.txt
-[DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367
-[DELETE] [CWD]/.xvc/b3/660/2cf
-[DELETE] [CWD]/.xvc/b3/660
 [DELETE] [CWD]/.xvc/b3/fef/e16/d9668f4c96ee7e719517f056aa23653fe9aaeddc9bfe81324fff534152/0.txt
-[DELETE] [CWD]/.xvc/b3/fef/e16/d9668f4c96ee7e719517f056aa23653fe9aaeddc9bfe81324fff534152
-[DELETE] [CWD]/.xvc/b3/fef/e16
-[DELETE] [CWD]/.xvc/b3/fef
-[DELETE] [CWD]/.xvc/b3
 
 $ ls .xvc/
 config.local.toml

--- a/book/src/ref/xvc-file-untrack.md
+++ b/book/src/ref/xvc-file-untrack.md
@@ -52,10 +52,6 @@ Without any options, it removes the file from Xvc tracking and the cache.
 ```console
 $ xvc file untrack data.txt
 [DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt
-[DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496
-[DELETE] [CWD]/.xvc/b3/c85/f3e
-[DELETE] [CWD]/.xvc/b3/c85
-[DELETE] [CWD]/.xvc/b3
 
 $ git status
 On branch [..]
@@ -73,10 +69,6 @@ lrwxr-xr-x [..] data.txt ⇒ [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b7230
 
 $ xvc file untrack data.txt
 [DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt
-[DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496
-[DELETE] [CWD]/.xvc/b3/c85/f3e
-[DELETE] [CWD]/.xvc/b3/c85
-[DELETE] [CWD]/.xvc/b3
 
 $ lsd -l
 .rw-rw-rw- [..] data.txt
@@ -98,14 +90,7 @@ $ xvc file untrack data.txt --restore-versions data-versions/
 [COPY] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367/0.txt -> [CWD]/data-versions/data-b3-660-2cf-f6a4.txt
 [COPY] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt -> [CWD]/data-versions/data-b3-c85-f3e-8108.txt
 [DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496/0.txt
-[DELETE] [CWD]/.xvc/b3/c85/f3e/8108a0d53da6b4869e5532a3b72301ed58d5824ed1394d52dbcabe9496
-[DELETE] [CWD]/.xvc/b3/c85/f3e
-[DELETE] [CWD]/.xvc/b3/c85
 [DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367/0.txt
-[DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367
-[DELETE] [CWD]/.xvc/b3/660/2cf
-[DELETE] [CWD]/.xvc/b3/660
-[DELETE] [CWD]/.xvc/b3
 
 $ lsd -l data-versions/
 .r--r--r-- [..] data-b3-660-2cf-f6a4.txt
@@ -136,9 +121,5 @@ $ tree .xvc/b3/
 
 $ xvc file untrack data2.txt
 [DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367/0.txt
-[DELETE] [CWD]/.xvc/b3/660/2cf/f6a4cbc23a78205463b7086d1b0831d3d74c063122f20c1c2ea0c2d367
-[DELETE] [CWD]/.xvc/b3/660/2cf
-[DELETE] [CWD]/.xvc/b3/660
-[DELETE] [CWD]/.xvc/b3
 
 ```

--- a/book/src/ref/xvc-storage-list.md
+++ b/book/src/ref/xvc-storage-list.md
@@ -19,15 +19,38 @@ Options:
 
 ## Examples
 
-List all storage configurations in the repository:
+The command works only in Xvc repositories.
 
-```shell
+```console
+$ git init
+...
+$ xvc init
+```
+
+Define two local storages:
+
+```console
+$ xvc storage new local --name backup-1 --path '../backup-1'
+$ xvc storage new local --name backup-2 --path '../backup-2'
+
+```
+
+You can list the storages and their GUIDs.
+
+```console
 $ xvc storage list
+Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+
+Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+
+
 ```
 
 ## Caveats
 
 This one uses the local configuration and doesn't try to connect storages.
-If it's listed with the command, it doesn't mean it's guaranteed to be able to pull or push.
 
+If a storage is listed, it doesn't mean it's guaranteed to be able to pull or push. 
+
+Xvc never stores credentials for storages. 
 

--- a/book/src/ref/xvc-storage-list.md
+++ b/book/src/ref/xvc-storage-list.md
@@ -39,9 +39,9 @@ You can list the storages and their GUIDs.
 
 ```console
 $ xvc storage list
-Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
 
-Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
 
 
 ```

--- a/book/src/ref/xvc-storage-list.md
+++ b/book/src/ref/xvc-storage-list.md
@@ -39,9 +39,9 @@ You can list the storages and their GUIDs.
 
 ```console
 $ xvc storage list
-Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
+Local:   backup-1	[..]	../backup-1
 
-Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
+Local:   backup-2	[..]	../backup-2
 
 
 ```

--- a/book/src/ref/xvc-storage-new-local.md
+++ b/book/src/ref/xvc-storage-new-local.md
@@ -75,18 +75,8 @@ You can remove the files you sent from your cache and workspace.
 ```console
 $ xvc file remove --from-cache dir-0001/
 [DELETE] [CWD]/.xvc/b3/3c6/70f/e91055c2be2e87890dba1e952d656d1e70dd196bf5530d379243c6e4aa/0.bin
-[DELETE] [CWD]/.xvc/b3/3c6/70f/e91055c2be2e87890dba1e952d656d1e70dd196bf5530d379243c6e4aa
-[DELETE] [CWD]/.xvc/b3/3c6/70f
-[DELETE] [CWD]/.xvc/b3/3c6
 [DELETE] [CWD]/.xvc/b3/7aa/354/0225bd33702c239454b63b31d1ea25721cbbfb491d6139d0b85b82d15d/0.bin
-[DELETE] [CWD]/.xvc/b3/7aa/354/0225bd33702c239454b63b31d1ea25721cbbfb491d6139d0b85b82d15d
-[DELETE] [CWD]/.xvc/b3/7aa/354
-[DELETE] [CWD]/.xvc/b3/7aa
 [DELETE] [CWD]/.xvc/b3/d7d/629/677c6d8df55ab3a1d694453c59f3ca0df494d3dc190aeef1e00abd96eb/0.bin
-[DELETE] [CWD]/.xvc/b3/d7d/629/677c6d8df55ab3a1d694453c59f3ca0df494d3dc190aeef1e00abd96eb
-[DELETE] [CWD]/.xvc/b3/d7d/629
-[DELETE] [CWD]/.xvc/b3/d7d
-[DELETE] [CWD]/.xvc/b3
 
 $ rm -rf dir-0001/
 ```

--- a/book/src/ref/xvc-storage-new-rsync.md
+++ b/book/src/ref/xvc-storage-new-rsync.md
@@ -86,18 +86,8 @@ You can remove the files you sent from your cache and workspace.
 ```console
 $ xvc file remove --from-cache dir-0001/
 [DELETE] [CWD]/.xvc/b3/3c6/70f/e91055c2be2e87890dba1e952d656d1e70dd196bf5530d379243c6e4aa/0.bin
-[DELETE] [CWD]/.xvc/b3/3c6/70f/e91055c2be2e87890dba1e952d656d1e70dd196bf5530d379243c6e4aa
-[DELETE] [CWD]/.xvc/b3/3c6/70f
-[DELETE] [CWD]/.xvc/b3/3c6
 [DELETE] [CWD]/.xvc/b3/7aa/354/0225bd33702c239454b63b31d1ea25721cbbfb491d6139d0b85b82d15d/0.bin
-[DELETE] [CWD]/.xvc/b3/7aa/354/0225bd33702c239454b63b31d1ea25721cbbfb491d6139d0b85b82d15d
-[DELETE] [CWD]/.xvc/b3/7aa/354
-[DELETE] [CWD]/.xvc/b3/7aa
 [DELETE] [CWD]/.xvc/b3/d7d/629/677c6d8df55ab3a1d694453c59f3ca0df494d3dc190aeef1e00abd96eb/0.bin
-[DELETE] [CWD]/.xvc/b3/d7d/629/677c6d8df55ab3a1d694453c59f3ca0df494d3dc190aeef1e00abd96eb
-[DELETE] [CWD]/.xvc/b3/d7d/629
-[DELETE] [CWD]/.xvc/b3/d7d
-[DELETE] [CWD]/.xvc/b3
 
 $ rm -rf dir-0001/
 ```

--- a/book/src/ref/xvc-storage-remove.md
+++ b/book/src/ref/xvc-storage-remove.md
@@ -22,6 +22,56 @@ Options:
           Print help (see a summary with '-h')
 
 ```
+
+## Examples
+
+The command works only in Xvc repositories.
+
+```console
+$ git init
+...
+$ xvc init
+```
+
+Define two local storages:
+
+```console
+$ xvc storage new local --name backup-1 --path '../backup-1'
+$ xvc storage new local --name backup-2 --path '../backup-2'
+
+```
+
+You can list the storages and their GUIDs.
+
+```console
+$ xvc storage list
+Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+
+Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+
+
+```
+
+Now when we remove `backup-1` and get the list, only one of them is listed.
+
+```console
+$ xvc storage remove --name backup-1
+Removed Storage Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+
+$ xvc storage list
+Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+
+Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+
+
+```
+
 ## Caveats
+
+This one uses the local configuration and doesn't try to connect storages.
+
+If a storage is listed, it doesn't mean it's guaranteed to be able to pull or push. 
+
+Xvc never stores credentials for storages. 
 
 

--- a/book/src/ref/xvc-storage-remove.md
+++ b/book/src/ref/xvc-storage-remove.md
@@ -45,9 +45,9 @@ You can list the storages and their GUIDs.
 
 ```console
 $ xvc storage list
-Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
 
-Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
 
 
 ```
@@ -56,12 +56,10 @@ Now when we remove `backup-1` and get the list, only one of them is listed.
 
 ```console
 $ xvc storage remove --name backup-1
-Removed Storage Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
+Removed Storage Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
 
 $ xvc storage list
-Local:   backup-1	675bc29a-24fc-40b1-af91-265f58c1b4fc	../backup-1
-
-Local:   backup-2	305b79ef-78d1-44c3-97c4-4242c90cab15	../backup-2
+Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
 
 
 ```

--- a/book/src/ref/xvc-storage-remove.md
+++ b/book/src/ref/xvc-storage-remove.md
@@ -45,9 +45,9 @@ You can list the storages and their GUIDs.
 
 ```console
 $ xvc storage list
-Local:   backup-1	631e1654-5c60-424b-b7ec-b75e4059fb2f	../backup-1
+Local:   backup-1[..]../backup-1
 
-Local:   backup-2	3eb92021-4767-4807-8e25-ed311e972c48	../backup-2
+Local:   backup-2[..]../backup-2
 
 
 ```
@@ -56,10 +56,10 @@ Now when we remove `backup-1` and get the list, only one of them is listed.
 
 ```console
 $ xvc storage remove --name backup-1
-Removed Storage Local:   backup-1	631e1654-5c60-424b-b7ec-b75e4059fb2f	../backup-1
+Removed Storage Local:   backup-1[..]../backup-1
 
 $ xvc storage list
-Local:   backup-2	3eb92021-4767-4807-8e25-ed311e972c48	../backup-2
+Local:   backup-2[..]../backup-2
 
 
 ```

--- a/book/src/ref/xvc-storage-remove.md
+++ b/book/src/ref/xvc-storage-remove.md
@@ -45,9 +45,9 @@ You can list the storages and their GUIDs.
 
 ```console
 $ xvc storage list
-Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
+Local:   backup-1	631e1654-5c60-424b-b7ec-b75e4059fb2f	../backup-1
 
-Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
+Local:   backup-2	3eb92021-4767-4807-8e25-ed311e972c48	../backup-2
 
 
 ```
@@ -56,10 +56,10 @@ Now when we remove `backup-1` and get the list, only one of them is listed.
 
 ```console
 $ xvc storage remove --name backup-1
-Removed Storage Local:   backup-1	4975b3f7-429b-4281-9d29-0148ee4eeb56	../backup-1
+Removed Storage Local:   backup-1	631e1654-5c60-424b-b7ec-b75e4059fb2f	../backup-1
 
 $ xvc storage list
-Local:   backup-2	ae6dc7ca-221c-40b2-8ebd-f8d04acabbad	../backup-2
+Local:   backup-2	3eb92021-4767-4807-8e25-ed311e972c48	../backup-2
 
 
 ```

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -13,7 +13,7 @@ use path_absolutize::*;
 use relative_path::{RelativePath, RelativePathBuf};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString, VariantNames};
-use xvc_logging::{output, uwr, XvcOutputSender};
+use xvc_logging::{info, output, uwr, XvcOutputSender};
 use xvc_walker::AbsolutePath;
 
 use std::ops::Deref;
@@ -317,7 +317,7 @@ impl XvcCachePath {
                 perm.set_readonly(false);
                 fs::set_permissions(&parent_abs_cp, perm)?;
                 uwr!(fs::remove_dir(&parent_abs_cp), output_snd);
-                output!(output_snd, "[DELETE] {}", parent_abs_cp.to_str().unwrap());
+                info!(output_snd, "[DELETE] {}", parent_abs_cp.to_str().unwrap());
             }
             rel_path = parent.to_relative_path_buf();
         }

--- a/ecs/src/ecs/event.rs
+++ b/ecs/src/ecs/event.rs
@@ -142,17 +142,9 @@ where
         }
     }
 
-    /// Appends an [Event::Add] event to the log
-    pub fn add(&mut self, entity: XvcEntity, value: T) {
-        self.0.push(Event::Add { entity, value });
-    }
-
-    /// Appends an [Event::Remove] event to the log.
-    ///
-    /// Note that this doesn't remove anything from the log.
-    /// Stores that use event log are supposed to remove the element from their maps after this.
-    pub fn remove(&mut self, entity: XvcEntity) {
-        self.0.push(Event::Remove { entity });
+    /// Adds an [Event] to the log, either an [Event::Add] or an [Event::Remove].
+    pub fn push_event(&mut self, event: Event<T>) {
+        self.0.push(event)
     }
 }
 

--- a/ecs/src/ecs/hstore.rs
+++ b/ecs/src/ecs/hstore.rs
@@ -144,11 +144,6 @@ impl<T> HStore<T> {
         }
     }
 
-    /// Calls the inner map's insert
-    pub fn insert(&mut self, entity: XvcEntity, value: T) -> Option<T> {
-        self.map.insert(entity, value)
-    }
-
     /// Creates values from `func` and gets new entities from `gen` to create new records.
     pub fn from_func<F>(gen: &XvcEntityGenerator, func: F) -> Result<HStore<T>>
     where
@@ -165,6 +160,21 @@ impl<T> HStore<T> {
             hstore.map.insert(key, value);
         }
         Ok(hstore)
+    }
+
+    /// Return the number of elements in this HStore
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Return true if there are no elements in this HStore
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Calls the inner map's insert
+    pub fn insert(&mut self, entity: XvcEntity, value: T) -> Option<T> {
+        self.map.insert(entity, value)
     }
 
     /// Returns a [HashSet] of values.

--- a/ecs/src/ecs/vstore.rs
+++ b/ecs/src/ecs/vstore.rs
@@ -106,7 +106,10 @@ where
     /// Insert an entity to the store.
     /// It also inserts an event to the log.
     pub fn insert(&mut self, entity: XvcEntity, value: T) {
-        self.current.add(entity, value.clone());
+        self.current.push_event(Event::Add {
+            entity,
+            value: value.clone(),
+        });
         self.vec.push((entity, value))
     }
 

--- a/ecs/src/ecs/xvcstore.rs
+++ b/ecs/src/ecs/xvcstore.rs
@@ -141,7 +141,11 @@ where
     /// [crate::HStore]). This function adds events to `current` set, and these are serialized.
     /// See https://github.com/iesahin/xvc/issues/45
     pub fn insert(&mut self, entity: XvcEntity, value: T) -> Option<T> {
-        self.current.add(entity, value.clone());
+        self.current.push_event(Event::Add {
+            entity,
+            value: value.clone(),
+        });
+
         match self.entity_index.get_mut(&value) {
             Some(v) => {
                 v.push(entity);
@@ -170,7 +174,8 @@ where
     pub fn remove(&mut self, entity: XvcEntity) -> Option<T> {
         if let Some(value) = self.map.remove(&entity) {
             if let Some(vec_e) = self.entity_index.get_mut(&value) {
-                self.current.remove(entity);
+                // Add a remove event to the current event log
+                self.current.push_event(Event::Remove { entity });
                 vec_e.retain(|e| *e != entity);
                 return Some(value);
             }

--- a/file/src/send/mod.rs
+++ b/file/src/send/mod.rs
@@ -43,7 +43,7 @@ pub struct SendCLI {
 
 /// Send a targets in `opts.targets` in `xvc_root`  to `opt.remote`
 pub fn cmd_send(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: SendCLI) -> Result<()> {
-    let remote = get_storage_record(output_snd, xvc_root, &opts.storage)?;
+    let storage = get_storage_record(output_snd, xvc_root, &opts.storage)?;
     let current_dir = xvc_root.config().current_dir()?;
     let targets = load_targets_from_store(output_snd, xvc_root, current_dir, &opts.targets)?;
 
@@ -80,7 +80,7 @@ pub fn cmd_send(output_snd: &XvcOutputSender, xvc_root: &XvcRoot, opts: SendCLI)
         })
         .collect();
 
-    remote
+    storage
         .send(
             output_snd,
             xvc_root,

--- a/lib/tests/common/mod.rs
+++ b/lib/tests/common/mod.rs
@@ -62,7 +62,7 @@ pub fn run_xvc(cwd: Option<&Path>, args: &[&str], verbosity: XvcVerbosity) -> Re
 }
 
 pub fn example_project_url() -> Result<String> {
-    Ok("http://e1.xvc.dev/example-xvc.tgz".to_string())
+    Ok("https://e1.xvc.dev/example-xvc.tgz".to_string())
 }
 
 pub fn example_project_template_path() -> Result<PathBuf> {

--- a/lib/tests/test_pipeline_run.rs
+++ b/lib/tests/test_pipeline_run.rs
@@ -7,8 +7,6 @@ use xvc_config::XvcVerbosity;
 
 use xvc::error::Result;
 
-use xvc::watch;
-
 #[test]
 fn test_pipeline_run() -> Result<()> {
     test_logging(log::LevelFilter::Warn);

--- a/lib/tests/test_storage_new_gcs.rs
+++ b/lib/tests/test_storage_new_gcs.rs
@@ -183,7 +183,7 @@ fn test_storage_new_gcs() -> Result<()> {
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
     let n_storage_files_before = file_list_before.lines().count();
-    let push_result = x(&["file", "send", "--to", "gcs-storage", the_file])?;
+    x(&["file", "send", "--to", "gcs-storage", the_file])?;
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
@@ -205,7 +205,7 @@ fn test_storage_new_gcs() -> Result<()> {
     // remove all cache
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "gcs-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "gcs-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_generic_rsync.rs
+++ b/lib/tests/test_storage_new_generic_rsync.rs
@@ -88,7 +88,7 @@ fn test_storage_new_generic_rsync() -> Result<()> {
                 .unwrap_or_else(|_| false)
         })
         .count();
-    let push_result = x(&["file", "send", "--to", "generic-storage", the_file])?;
+    x(&["file", "send", "--to", "generic-storage", the_file])?;
 
     let file_list = sh(format!("ssh {url} 'ls -1R {storage_dir_name} | grep bin'"));
 
@@ -109,7 +109,7 @@ fn test_storage_new_generic_rsync() -> Result<()> {
     let cache_dir = xvc_root.xvc_dir().join("b3");
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "generic-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "generic-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_local.rs
+++ b/lib/tests/test_storage_new_local.rs
@@ -117,7 +117,7 @@ fn test_storage_new_local() -> Result<()> {
         })
         .count();
     assert!(n_storage_files_after == n_local_files_after_pull);
-    let tree_result = sh("tree")?;
+    sh("tree")?;
     assert!(PathBuf::from(the_file).exists());
 
     // When we reinit with the same storage path, it shouldn't update the GUID.

--- a/lib/tests/test_storage_new_r2.rs
+++ b/lib/tests/test_storage_new_r2.rs
@@ -5,7 +5,7 @@ use std::{env, fs, path::PathBuf};
 use log::LevelFilter;
 
 use subprocess::Exec;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;
@@ -157,7 +157,7 @@ fn test_storage_new_r2() -> Result<()> {
         common::run_xvc(Some(xvc_root.as_path()), cmd, XvcVerbosity::Trace)
     };
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "r2",
@@ -188,7 +188,7 @@ fn test_storage_new_r2() -> Result<()> {
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
     let n_storage_files_before = file_list_before.lines().count();
-    let push_result = x(&["file", "send", "--to", "r2-storage", the_file])?;
+    x(&["file", "send", "--to", "r2-storage", the_file])?;
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
@@ -210,7 +210,7 @@ fn test_storage_new_r2() -> Result<()> {
     // remove all cache
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "r2-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "r2-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -227,7 +227,7 @@ fn test_storage_new_r2() -> Result<()> {
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
     fs::remove_file(the_file)?;
 
-    let pull_result = x(&["file", "bring", "--from", "r2-storage"])?;
+    x(&["file", "bring", "--from", "r2-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -248,7 +248,7 @@ fn test_storage_new_r2() -> Result<()> {
     env::remove_var("R2_ACCESS_KEY_ID");
     env::remove_var("R2_SECRET_ACCESS_KEY");
 
-    let pull_result_2 = x(&["file", "bring", "--from", "r2-storage"])?;
+    x(&["file", "bring", "--from", "r2-storage"])?;
 
     clean_up(&xvc_root)
 }

--- a/lib/tests/test_storage_new_rsync.rs
+++ b/lib/tests/test_storage_new_rsync.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 use common::*;
 use subprocess::Exec;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;
@@ -49,7 +49,7 @@ fn test_storage_new_rsync() -> Result<()> {
         "ssh {url} 'test -e {storage_dir_name} && rm -rf {storage_dir_name}'"
     ));
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "rsync",
@@ -71,7 +71,7 @@ fn test_storage_new_rsync() -> Result<()> {
 
     let the_file = "file-0000.bin";
 
-    let file_track_result = x(&["file", "track", the_file])?;
+    x(&["file", "track", the_file])?;
 
     let n_storage_files_before = jwalk::WalkDir::new(local_test_dir)
         .into_iter()
@@ -81,7 +81,7 @@ fn test_storage_new_rsync() -> Result<()> {
                 .unwrap_or_else(|_| false)
         })
         .count();
-    let push_result = x(&["file", "send", "--to", "rsync-storage", the_file])?;
+    x(&["file", "send", "--to", "rsync-storage", the_file])?;
 
     let file_list = sh(format!("ssh {url} 'ls -1R {storage_dir_name} | grep bin'"));
 
@@ -102,7 +102,7 @@ fn test_storage_new_rsync() -> Result<()> {
     let cache_dir = xvc_root.xvc_dir().join("b3");
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "rsync-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "rsync-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -119,7 +119,7 @@ fn test_storage_new_rsync() -> Result<()> {
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
     fs::remove_file(the_file)?;
 
-    let pull_result = x(&["file", "bring", "--from", "rsync-storage"])?;
+    x(&["file", "bring", "--from", "rsync-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_new_wasabi.rs
+++ b/lib/tests/test_storage_new_wasabi.rs
@@ -5,7 +5,7 @@ use log::LevelFilter;
 
 use common::run_in_temp_xvc_dir;
 use subprocess::Exec;
-use xvc::{error::Result, watch};
+use xvc::error::Result;
 use xvc_config::XvcVerbosity;
 use xvc_core::XvcRoot;
 use xvc_storage::storage::XVC_STORAGE_GUID_FILENAME;
@@ -154,7 +154,7 @@ fn test_storage_new_wasabi() -> Result<()> {
         common::run_xvc(Some(&xvc_root), cmd, XvcVerbosity::Warn)
     };
 
-    let out = x(&[
+    x(&[
         "storage",
         "new",
         "wasabi",
@@ -176,7 +176,7 @@ fn test_storage_new_wasabi() -> Result<()> {
 
     let the_file = "file-0000.bin";
 
-    let file_track_result = x(&["file", "track", the_file])?;
+    x(&["file", "track", the_file])?;
 
     let cache_dir = xvc_root.xvc_dir().join("b3");
 
@@ -185,7 +185,7 @@ fn test_storage_new_wasabi() -> Result<()> {
         &format!("| rg {storage_prefix} | rg 0.bin"),
     );
     let n_storage_files_before = file_list_before.lines().count();
-    let push_result = x(&["file", "send", "--to", "wasabi-storage", the_file])?;
+    x(&["file", "send", "--to", "wasabi-storage", the_file])?;
 
     let file_list_after = s3cmd(
         &format!("ls --recursive s3://{bucket_name}"),
@@ -207,7 +207,7 @@ fn test_storage_new_wasabi() -> Result<()> {
     // remove all cache
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
 
-    let fetch_result = x(&["file", "bring", "--no-recheck", "--from", "wasabi-storage"])?;
+    x(&["file", "bring", "--no-recheck", "--from", "wasabi-storage"])?;
 
     let n_local_files_after_fetch = jwalk::WalkDir::new(&cache_dir)
         .into_iter()
@@ -224,7 +224,7 @@ fn test_storage_new_wasabi() -> Result<()> {
     sh(format!("rm -rf {}", cache_dir.to_string_lossy()));
     fs::remove_file(the_file)?;
 
-    let pull_result = x(&["file", "bring", "--from", "wasabi-storage"])?;
+    x(&["file", "bring", "--from", "wasabi-storage"])?;
 
     let n_local_files_after_pull = jwalk::WalkDir::new(&cache_dir)
         .into_iter()

--- a/lib/tests/test_storage_remove.rs
+++ b/lib/tests/test_storage_remove.rs
@@ -1,0 +1,67 @@
+mod common;
+
+use log::LevelFilter;
+
+use xvc::error::Result;
+use xvc_config::XvcVerbosity;
+
+#[test]
+fn test_storage_remove() -> Result<()> {
+    common::test_logging(LevelFilter::Trace);
+    let xvc_root = common::run_in_temp_xvc_dir()?;
+
+    let x = |cmd: &[&str]| -> Result<String> {
+        common::run_xvc(Some(&xvc_root), cmd, XvcVerbosity::Trace)
+    };
+
+    let storage_names = ["backup-1", "backup-2"];
+
+    for name in storage_names {
+        let storage_dir = common::random_temp_dir(Some(name));
+        x(&[
+            "storage",
+            "new",
+            "local",
+            "--name",
+            name,
+            "--path",
+            storage_dir.to_string_lossy().as_ref(),
+        ])?;
+    }
+
+    let storage_list: Vec<String> = x(&["storage", "list"])?
+        .lines()
+        .filter_map(|s| {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .collect();
+    assert!(
+        storage_list.len() == storage_names.len(),
+        "storage_list: {storage_list:?}"
+    );
+
+    let remove_output = x(&["storage", "remove", "--name", storage_names[0]])?;
+    assert!(remove_output.contains(storage_names[0]));
+
+    let storage_list: Vec<String> = x(&["storage", "list"])?
+        .lines()
+        .filter_map(|s| {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .collect();
+
+    assert!(
+        storage_list.len() == storage_names.len() - 1,
+        "remove_output: {remove_output:?}\n\nstorage_list: {storage_list:?}"
+    );
+
+    Ok(())
+}

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -4,5 +4,5 @@
 
 # XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo test --features test-ci -p xvc --test z_test_docs
 
-XVC_TRYCMD_TESTS=storage TRYCMD=overwrite rws cargo test --features test-ci -p xvc
+# XVC_TRYCMD_TESTS=storage TRYCMD=overwrite rws cargo test --features test-ci -p xvc
 

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -4,3 +4,5 @@
 
 # XVC_TRYCMD_TESTS=storage,file,pipeline,core,start TRYCMD=overwrite cargo test --features test-ci -p xvc --test z_test_docs
 
+XVC_TRYCMD_TESTS=storage TRYCMD=overwrite rws cargo test --features test-ci -p xvc
+

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -60,8 +60,11 @@ pub enum Error {
     #[error("No Guid found for Xvc Repository")]
     NoRepositoryGuidFound,
 
-    #[error("Cannot find remote with identifier: {identifier}")]
+    #[error("Cannot find storage with identifier: {identifier}")]
     CannotFindStorageWithIdentifier { identifier: StorageIdentifier },
+
+    #[error("Cannot remove storage with identifier: {identifier}")]
+    CannotRemoveStorageWithIdentifier { identifier: StorageIdentifier },
 
     #[error("Process Exec Error: {source}")]
     ProcessExecError {


### PR DESCRIPTION
- **add examples to storage list**
- **add examples to storage remove**
- **don't output removed directories**
- **add / remove is now merged into push_event**
- **len and is_empty for hstore**
- **new test for storage remove**
- **new errors for storage remove**
- **rename**
- **fix warnings**
- **update test script**


<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new feature for managing storage, including the ability to add and remove storage configurations, and updates related documentation and tests.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant XVC CLI
    participant StorageManager
    participant LocalConfig
    participant FileSystem

    User->>XVC CLI: xvc storage new [type] --name [name] --path [path]
    XVC CLI->>StorageManager: Create new storage record
    StorageManager->>LocalConfig: Save storage configuration
    StorageManager-->>User: Storage created

    User->>XVC CLI: xvc storage list
    XVC CLI->>StorageManager: Get all storages
    StorageManager->>LocalConfig: Read storage records
    StorageManager-->>User: Display storage list

    User->>XVC CLI: xvc storage remove --name [name]
    XVC CLI->>StorageManager: Remove storage
    StorageManager->>LocalConfig: Delete storage record
    StorageManager-->>User: Storage removed

    User->>XVC CLI: xvc file send --to [storage] [file]
    XVC CLI->>StorageManager: Send file to storage
    StorageManager->>FileSystem: Copy file to storage location
    StorageManager-->>User: File sent

    User->>XVC CLI: xvc file bring --from [storage]
    XVC CLI->>StorageManager: Retrieve file from storage  
    StorageManager->>FileSystem: Copy file from storage
    StorageManager-->>User: File retrieved
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-2942a030433f49d75324f98db5cdf4383969e8cb2c453bb22da4bb24c4a200fc>book/src/ref/xvc-file-remove.md</a></td><td>Updated examples to reflect the removal of directories.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-ad5a3aca70d4b8fce9786784135046b2d20034c9b8abeb2813c9b99beef59fcf>book/src/ref/xvc-file-untrack.md</a></td><td>Updated examples to reflect the removal of directories.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-7cceeced87c67a8743191851ce7b4d1321268bb719c15d512497d4e0cc163772>book/src/ref/xvc-storage-list.md</a></td><td>Added examples for listing storage configurations.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-9a34e9a9e5c793e928aaf5c94453d862c79fd875329a67f3cc130eadfa66b1ea>book/src/ref/xvc-storage-new-local.md</a></td><td>Updated examples for creating new local storage.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-b2d6731757faf504b9dfcc0c8de9b636750adca3762c5cdbf621a28643cbed7a>book/src/ref/xvc-storage-new-rsync.md</a></td><td>Updated examples for creating new rsync storage.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-45b05d10e79624be537e83d18d147af8d82312498235a36ce1e332f96f0a1997>book/src/ref/xvc-storage-remove.md</a></td><td>Added examples for removing storage.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-a2e98d08aa546a28f9649ebd9cfafb5a419eb00c1bc15edbae777fd848503c44>core/src/types/xvcpath.rs</a></td><td>Updated logging to use info level for delete operations.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-e505c4b6735e9a694a0d116c1a2654cd480bd39e140304018326d090073b870f>ecs/src/ecs/event.rs</a></td><td>Merged add and remove events into a single push_event function.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-dba148144b8c067a3972b53ae2a2990ef79792f7713275a254935033b10f499f>ecs/src/ecs/hstore.rs</a></td><td>Added len and is_empty methods for HStore.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-792eb1a254340e433c00af2a53d597afc2b6dfbf7a62bb580b37d71c25ddb795>ecs/src/ecs/vstore.rs</a></td><td>Updated insert method to use push_event for adding entities.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-efa1d79623c390e4c59bb2b0d5eefef279420cfc0f3af1cd2d2a0313a5413b08>ecs/src/ecs/xvcstore.rs</a></td><td>Updated insert and remove methods to use push_event for event logging.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-b2615c94986b7f43a8f5563c533874447883079165e3959ef758d55f7272ab6c>file/src/send/mod.rs</a></td><td>Renamed variable for clarity.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-696b8c40cf6cde2c553c36848fe22d6e534bb8f600d92a58fe0483d054d1d9a3>lib/tests/common/mod.rs</a></td><td>Updated example project URL to use HTTPS.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-0015596f2a1d99b1765ede7487dec19cca94d8f902b78c3f66c63554f2244a16>lib/tests/test_storage_remove.rs</a></td><td>Added tests for storage removal functionality.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-7c00bbca8ace472a25cbb5323290867586edd412397dbce1850d65e0d53f6de5>storage/src/error.rs</a></td><td>Updated error messages for clarity.</td></tr>
<tr><td><a href=https://github.com/iesahin/xvc/pull/270/files#diff-260f5ff8923ba51b9000db126e6a8b204153921963af8dc7c4e1f5689c122601>storage/src/lib.rs</a></td><td>Implemented storage removal functionality.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`, `.zsh`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








