### PR TITLE
feat: Add automated migration from v1 to v2 repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,12 @@ jobs:
     strategy:
       matrix:
         platform:
-          - os-name: FreeBSD-x86_64
-            runs-on: ubuntu-latest
-            target: x86_64-unknown-freebsd
-            command: build
-            args: "--release --features=bundled-openssl"
+          # FIXME: This fails because of missing -lgeom 
+          # - os-name: FreeBSD-x86_64
+          #   runs-on: ubuntu-latest
+          #   target: x86_64-unknown-freebsd
+          #   command: build
+          #   args: "--release --features=bundled-openssl"
 
           - os-name: Linux-x86_64
             runs-on: ubuntu-latest

--- a/config/src/configuration.rs
+++ b/config/src/configuration.rs
@@ -170,6 +170,9 @@ pub struct OptionalCoreConfig {
     pub xvc_repo_version: Option<u8>,
     /// Optional verbosity level for logging.
     pub verbosity: Option<String>,
+    /// Optional GUID for the repository.
+    /// This is a legacy field and should be migrated to .xvc/guid file.
+    pub guid: Option<String>,
 }
 
 /// Optional Git integration configuration for Xvc, used for partial updates.

--- a/lib/tests/test_config_migration.rs
+++ b/lib/tests/test_config_migration.rs
@@ -1,0 +1,70 @@
+mod common;
+use common::*;
+use std::fs;
+use xvc::error::Result;
+use xvc_core::XvcVerbosity;
+use xvc_core::configuration::{OptionalCoreConfig, OptionalGitConfig, XvcOptionalConfiguration};
+
+#[test]
+fn test_config_migration_core_guid() -> Result<()> {
+    test_logging(log::LevelFilter::Trace);
+    let xvc_root = run_in_temp_xvc_dir()?;
+    let xvc_dir = xvc_root.xvc_dir();
+    let config_path = xvc_dir.join("config.toml");
+    let guid_path = xvc_dir.join("guid");
+    let gitignore_path = xvc_root.absolute_path().join(".gitignore");
+
+    // 1. Get original GUID
+    let original_guid = fs::read_to_string(&guid_path)?;
+
+    // 2. Remove .xvc/guid
+    fs::remove_file(&guid_path)?;
+    assert!(!guid_path.exists());
+
+    // 3. Add core.guid to config.toml
+    let config = XvcOptionalConfiguration {
+        core: Some(OptionalCoreConfig {
+            verbosity: Some("warn".to_string()),
+            guid: Some(original_guid.trim().to_string()),
+            ..Default::default()
+        }),
+        git: Some(OptionalGitConfig {
+            use_git: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let new_config_content = toml::to_string(&config).unwrap();
+    fs::write(&config_path, new_config_content)?;
+
+    // 4. Modify .gitignore to remove the lines we want to test restoration of
+    let gitignore_content = fs::read_to_string(&gitignore_path)?;
+    let new_gitignore_content = gitignore_content
+        .lines()
+        .filter(|l| !l.contains("!.xvc/guid") && !l.contains("!.xvc/pipelines/"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&gitignore_path, new_gitignore_content)?;
+
+    // 5. Run an Xvc command to trigger migration
+    run_xvc(Some(&xvc_root), &["root"], XvcVerbosity::Trace)?;
+
+    // 6. Assertions
+
+    // .xvc/guid should exist and contain the original guid
+    assert!(guid_path.exists(), "guid file should exist after migration");
+    let migrated_guid = fs::read_to_string(&guid_path)?;
+    assert_eq!(migrated_guid.trim(), original_guid.trim(), "Guid content mismatch");
+
+    // config.toml should NOT contain guid = ...
+    let migrated_config = fs::read_to_string(&config_path)?;
+    assert!(!migrated_config.contains("guid ="), "config.toml should not contain guid key");
+    
+    // .gitignore should contain the restored lines
+    let migrated_gitignore = fs::read_to_string(&gitignore_path)?;
+    assert!(migrated_gitignore.contains("!.xvc/guid"), ".gitignore should contain !.xvc/guid");
+    assert!(migrated_gitignore.contains("!.xvc/pipelines/"), ".gitignore should contain !.xvc/pipelines/");
+
+    clean_up(&xvc_root)
+}


### PR DESCRIPTION
Closes #280 

This pull request implements a migration process for the repository GUID field in the configuration, moving it from the legacy `core.guid` field in `config.toml` to a dedicated `.xvc/guid` file, and ensures related entries are present in `.gitignore`. It also adds a comprehensive test to verify the migration logic.

**Migration logic and config structure updates:**

* Added an optional `guid` field to the `OptionalCoreConfig` struct as a legacy field, with a note that it should be migrated to `.xvc/guid` (`config/src/configuration.rs`).
* Updated the `XvcConfig` initialization logic to detect and migrate the `core.guid` field from `config.toml` to `.xvc/guid` when present, and to clean up the legacy field from the config file (`config/src/lib.rs`) [[1]](diffhunk://#diff-4429d8a75f4f230ae4b5c590d76a1a5a9aa1f2553bc4740c5f3d7dc0137cd704L223-R223) [[2]](diffhunk://#diff-4429d8a75f4f230ae4b5c590d76a1a5a9aa1f2553bc4740c5f3d7dc0137cd704R233-R240).
* Implemented the `migrate_config_to_07` function to handle the migration process, including updating `.gitignore` to ensure `.xvc/guid` and `.xvc/pipelines/` are not ignored, and removing the `guid` field from the config file (`config/src/lib.rs`).

**Testing:**

* Added a new test `test_config_migration_core_guid` to verify the migration process, ensuring the `guid` is moved, config is cleaned up, and `.gitignore` is updated (`lib/tests/test_config_migration.rs`).

**Other changes:**

* Commented out the FreeBSD build target in the GitHub Actions release workflow due to a missing library issue (`.github/workflows/release.yml`).