### PR TITLE
test: Add integration tests for untested subcommands

### DIFF
--- a/lib/tests/common/mod.rs
+++ b/lib/tests/common/mod.rs
@@ -57,6 +57,42 @@ pub fn run_xvc(cwd: Option<&Path>, args: &[&str], verbosity: XvcVerbosity) -> Re
     Ok(output_str)
 }
 
+/// Run xvc without asserting success. Returns (success, stdout, stderr).
+pub fn run_xvc_unchecked(cwd: Option<&Path>, args: &[&str]) -> Result<(bool, String, String)> {
+    let mut cmd = cargo_bin_cmd!("xvc");
+    let prepared = match cwd {
+        Some(cwd) => cmd.args(args).current_dir(cwd),
+        None => cmd.args(args),
+    };
+    let output = prepared.output()?;
+    Ok((
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).replace("\\\n", "\n"),
+        String::from_utf8_lossy(&output.stderr).replace("\\\n", "\n"),
+    ))
+}
+
+/// All regular files under the `.xvc/b3` content-addressed cache
+pub fn cache_paths(xvc_root: &XvcRoot) -> Vec<PathBuf> {
+    let cache_dir = xvc_root.absolute_path().join(".xvc/b3");
+    if !cache_dir.exists() {
+        return Vec::new();
+    }
+    let mut paths: Vec<PathBuf> = jwalk::WalkDir::new(&cache_dir)
+        .into_iter()
+        .filter_map(|e| {
+            let e = e.ok()?;
+            if e.file_type().is_file() {
+                Some(e.path())
+            } else {
+                None
+            }
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
 pub fn example_project_url() -> Result<String> {
     Ok("https://e1.xvc.dev/example-xvc.tgz".to_string())
 }

--- a/lib/tests/test_check_ignore.rs
+++ b/lib/tests/test_check_ignore.rs
@@ -1,0 +1,86 @@
+mod common;
+use common::*;
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use xvc::error::Result;
+use xvc_core::XvcVerbosity;
+
+fn append(path: &Path, line: &str) -> Result<()> {
+    let mut f = OpenOptions::new().append(true).open(path)?;
+    writeln!(f, "{line}")?;
+    Ok(())
+}
+
+#[test]
+fn test_check_ignore() -> Result<()> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["check-ignore"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+
+    let xvcignore = xvc_root.join(&PathBuf::from(".xvcignore"));
+    append(&xvcignore, "my-dir/my-file")?;
+
+    // Paths given on the CLI are checked against .xvcignore rules
+    let out = x(&["my-dir/my-file", "another-dir/another-file"])?;
+    let ignore_line = out
+        .lines()
+        .find(|l| l.contains("my-dir/my-file"))
+        .expect(&out);
+    assert!(ignore_line.contains("[IGNORE]"), "{out}");
+    let no_match_line = out
+        .lines()
+        .find(|l| l.contains("another-dir/another-file"))
+        .expect(&out);
+    assert!(no_match_line.contains("[NO MATCH]"), "{out}");
+
+    // Whitelist patterns are reported separately
+    append(&xvcignore, "!another-dir/*")?;
+    let out = x(&["my-dir/my-file", "another-dir/another-file"])?;
+    let whitelist_line = out
+        .lines()
+        .find(|l| l.contains("another-dir/another-file"))
+        .expect(&out);
+    assert!(whitelist_line.contains("[WHITELIST]"), "{out}");
+
+    // Without CLI targets, paths are read from stdin
+    let output = cargo_bin_cmd!("xvc")
+        .args(["check-ignore"])
+        .current_dir(xvc_root.absolute_path())
+        .write_stdin("my-dir/my-file\n")
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[IGNORE]") && stdout.contains("my-dir/my-file"),
+        "stdout: {stdout}"
+    );
+
+    // Rules can be read from another ignore file, e.g. .gitignore
+    let gitignore = xvc_root.join(&PathBuf::from(".gitignore"));
+    append(&gitignore, "ignored-by-git.txt")?;
+    let out = x(&[
+        "--ignore-filename",
+        ".gitignore",
+        "ignored-by-git.txt",
+        "not-ignored.txt",
+    ])?;
+    let git_ignored_line = out
+        .lines()
+        .find(|l| l.contains("ignored-by-git.txt"))
+        .expect(&out);
+    assert!(git_ignored_line.contains("[IGNORE]"), "{out}");
+    let not_ignored_line = out
+        .lines()
+        .find(|l| l.contains("not-ignored.txt"))
+        .expect(&out);
+    assert!(not_ignored_line.contains("[NO MATCH]"), "{out}");
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_file_carry_in.rs
+++ b/lib/tests/test_file_carry_in.rs
@@ -1,0 +1,62 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::PathBuf;
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const CONTENT: &str = "Oh, data, my, data\n";
+
+fn setup() -> Result<XvcRoot> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), CONTENT)?;
+    Ok(xvc_root)
+}
+
+#[test]
+fn test_file_carry_in() -> Result<()> {
+    let xvc_root = setup()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["file"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+    let p = |s: &str| xvc_root.join(&PathBuf::from(s));
+
+    x(&["track", "data.txt"])?;
+    let initial_cache = cache_paths(&xvc_root);
+    assert_eq!(initial_cache.len(), 1);
+    assert_eq!(fs::read_to_string(&initial_cache[0])?, CONTENT);
+
+    // Carrying in an unchanged file is a no-op
+    x(&["carry-in", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root), initial_cache);
+
+    // Carrying in a changed file adds a new cache version and keeps the old one
+    let new_content = "carried in version\n";
+    fs::write(p("data.txt"), new_content)?;
+    x(&["carry-in", "data.txt"])?;
+    let cache_after_change = cache_paths(&xvc_root);
+    assert_eq!(cache_after_change.len(), 2);
+    let new_cache_file = cache_after_change
+        .iter()
+        .find(|f| !initial_cache.contains(f))
+        .expect("a new cache file should be created");
+    assert_eq!(fs::read_to_string(new_cache_file)?, new_content);
+
+    // --force re-adds the file even if the content digest is unchanged
+    x(&["carry-in", "--force", "--no-parallel", "data.txt"])?;
+    let cache_after_force = cache_paths(&xvc_root);
+    assert_eq!(cache_after_force.len(), 2);
+    assert_eq!(fs::read_to_string(new_cache_file)?, new_content);
+
+    // Carry-in with explicit text/binary digest mode
+    fs::write(p("data.txt"), "binary mode version\n")?;
+    x(&["carry-in", "--text-or-binary", "binary", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 3);
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_file_copy.rs
+++ b/lib/tests/test_file_copy.rs
@@ -1,0 +1,98 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const CONTENT: &str = "Oh, data, my, data\n";
+
+fn setup() -> Result<XvcRoot> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), CONTENT)?;
+    Ok(xvc_root)
+}
+
+fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .map(|md| md.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_file_copy() -> Result<()> {
+    let xvc_root = setup()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["file"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+
+    x(&["track", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Copying a tracked file rechecks the destination without duplicating the cache
+    x(&["copy", "data.txt", "data2.txt"])?;
+    let data2 = xvc_root.join(&PathBuf::from("data2.txt"));
+    assert!(data2.exists());
+    assert_eq!(fs::read_to_string(&data2)?, CONTENT);
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // The recheck method of the destination can differ from the source
+    x(&["copy", "data.txt", "data3.txt", "--as", "symlink"])?;
+    let data3 = xvc_root.join(&PathBuf::from("data3.txt"));
+    assert!(is_symlink(&data3), "data3.txt should be a symlink");
+    let link_target = fs::read_link(&data3)?;
+    assert!(
+        link_target.to_string_lossy().contains(".xvc/b3"),
+        "symlink should point into the cache: {link_target:?}"
+    );
+
+    // Glob source with a directory destination
+    x(&["copy", "data*", "another-set/", "--as", "hardlink"])?;
+    for f in ["data.txt", "data2.txt", "data3.txt"] {
+        let copied = xvc_root.join(&PathBuf::from("another-set")).join(f);
+        assert!(copied.exists(), "another-set/{f} should exist");
+        assert_eq!(fs::read_to_string(&copied)?, CONTENT);
+    }
+    // Hardlinked copies don't add new cache files
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Copying from a changed source is refused
+    fs::write(
+        xvc_root.join(&PathBuf::from("data.txt")),
+        "changed content\n",
+    )?;
+    let (success, stdout, stderr) =
+        run_xvc_unchecked(Some(&xvc_root), &["file", "copy", "data.txt", "data5.txt"])?;
+    assert!(!success, "copy from a changed source should fail");
+    assert!(
+        format!("{stdout}{stderr}").contains("Sources have changed"),
+        "stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(!xvc_root.join(&PathBuf::from("data5.txt")).exists());
+
+    // A missing workspace file can still be copied from the cache
+    fs::remove_file(xvc_root.join(&PathBuf::from("data.txt")))?;
+    x(&["copy", "data.txt", "data6.txt"])?;
+    let data6 = xvc_root.join(&PathBuf::from("data6.txt"));
+    assert!(data6.exists());
+    assert_eq!(fs::read_to_string(&data6)?, CONTENT);
+
+    // --no-recheck only records the copy without materializing it
+    x(&["copy", "data.txt", "data7.txt", "--no-recheck"])?;
+    let data7 = xvc_root.join(&PathBuf::from("data7.txt"));
+    assert!(!data7.exists(), "data7.txt should not be rechecked yet");
+    let list_out = x(&["list", "data7.txt"])?;
+    assert!(list_out.contains("data7.txt"), "{list_out}");
+
+    // ... until it's explicitly rechecked
+    x(&["recheck", "data7.txt"])?;
+    assert!(data7.exists());
+    assert_eq!(fs::read_to_string(&data7)?, CONTENT);
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_file_move.rs
+++ b/lib/tests/test_file_move.rs
@@ -1,0 +1,75 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const CONTENT: &str = "Oh, data, my, data\n";
+
+fn setup() -> Result<XvcRoot> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), CONTENT)?;
+    Ok(xvc_root)
+}
+
+fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .map(|md| md.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_file_move() -> Result<()> {
+    let xvc_root = setup()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["file"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+    let p = |s: &str| xvc_root.join(&PathBuf::from(s));
+
+    x(&["track", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Moving renames the workspace file and keeps the cache intact
+    x(&["move", "data.txt", "data2.txt"])?;
+    assert!(!p("data.txt").exists(), "data.txt should be moved away");
+    assert!(p("data2.txt").exists());
+    assert_eq!(fs::read_to_string(p("data2.txt"))?, CONTENT);
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Move can change the recheck method
+    x(&["move", "data2.txt", "data3.txt", "--as", "symlink"])?;
+    assert!(!p("data2.txt").exists());
+    assert!(is_symlink(&p("data3.txt")), "data3.txt should be a symlink");
+
+    // A file missing from the workspace can still be moved; it's rechecked from the cache
+    fs::remove_file(p("data3.txt"))?;
+    x(&["move", "data3.txt", "data4.txt"])?;
+    assert!(p("data4.txt").exists() || is_symlink(&p("data4.txt")));
+
+    // Glob source with a directory destination
+    x(&["copy", "data4.txt", "data5.txt"])?;
+    x(&["move", "data*", "another-set/"])?;
+    assert!(p("another-set/data4.txt").exists());
+    assert!(p("another-set/data5.txt").exists());
+    assert!(!p("data4.txt").exists());
+    assert!(!p("data5.txt").exists());
+
+    // --no-recheck records the move without materializing the destination
+    x(&["move", "another-set/data5.txt", "data6.txt", "--no-recheck"])?;
+    assert!(!p("another-set/data5.txt").exists());
+    assert!(!p("data6.txt").exists());
+    let list_out = x(&["list", "data6.txt"])?;
+    assert!(list_out.contains("data6.txt"), "{list_out}");
+
+    x(&["recheck", "data6.txt"])?;
+    assert!(p("data6.txt").exists());
+    assert_eq!(fs::read_to_string(p("data6.txt"))?, CONTENT);
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_file_remove.rs
+++ b/lib/tests/test_file_remove.rs
@@ -1,0 +1,119 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::PathBuf;
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const CONTENT: &str = "Oh, data, my, data\n";
+
+fn setup() -> Result<XvcRoot> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), CONTENT)?;
+    Ok(xvc_root)
+}
+
+#[test]
+fn test_file_remove() -> Result<()> {
+    let xvc_root = setup()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["file"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+    let p = |s: &str| xvc_root.join(&PathBuf::from(s));
+
+    x(&["track", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Either --from-cache or --from-storage is required
+    let (success, _stdout, stderr) =
+        run_xvc_unchecked(Some(&xvc_root), &["file", "remove", "data.txt"])?;
+    assert!(
+        !success,
+        "remove without --from-cache/--from-storage should fail"
+    );
+    assert!(
+        stderr.contains("required arguments"),
+        "stderr should be a clap error: {stderr}"
+    );
+
+    // --from-cache deletes the cached copy; the file stays tracked and in the workspace
+    let remove_out = x(&["remove", "--from-cache", "data.txt"])?;
+    assert!(remove_out.contains("[DELETE]"), "{remove_out}");
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+    assert!(p("data.txt").exists());
+
+    // carry-in --force puts it back to the cache
+    x(&["carry-in", "--force", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+
+    // Create a second version, then delete only the old one by its hash prefix
+    fs::write(p("data.txt"), "second version\n")?;
+    x(&["carry-in", "data.txt"])?;
+    let all_versions = cache_paths(&xvc_root);
+    assert_eq!(all_versions.len(), 2);
+    let old_cache_file = all_versions
+        .iter()
+        .find(|f| fs::read_to_string(f).map(|c| c == CONTENT).unwrap_or(false))
+        .expect("the first version should be in the cache");
+    // Cache paths are .xvc/b3/<3-char>/<3-char>/<rest>/0.ext; versions are
+    // specified with dash-separated hash prefixes like c85-f3e
+    let components: Vec<String> = old_cache_file
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .collect();
+    let b3_pos = components
+        .iter()
+        .position(|c| c == "b3")
+        .expect("cache path should contain b3");
+    let version_prefix = format!("{}-{}", components[b3_pos + 1], components[b3_pos + 2]);
+    x(&[
+        "remove",
+        "--from-cache",
+        "--only-version",
+        &version_prefix,
+        "data.txt",
+    ])?;
+    let remaining = cache_paths(&xvc_root);
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(fs::read_to_string(&remaining[0])?, "second version\n");
+
+    // --all-versions empties the cache for the target
+    x(&["remove", "--from-cache", "--all-versions", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+
+    // Deduplicated cache files are kept unless --force is given
+    x(&["carry-in", "--force", "data.txt"])?;
+    x(&["copy", "data.txt", "data2.txt", "--as", "symlink"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+    let remove_out = x(&["remove", "--from-cache", "data.txt"])?;
+    assert!(
+        remove_out.contains("also used by"),
+        "should report deduplicated use: {remove_out}"
+    );
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+    // The dedup warning is emitted at warn level, so run with -v and check both streams
+    let (success, stdout, stderr) = run_xvc_unchecked(
+        Some(&xvc_root),
+        &[
+            "-v",
+            "file",
+            "remove",
+            "--from-cache",
+            "--force",
+            "data.txt",
+        ],
+    )?;
+    assert!(success, "forced removal should succeed: {stderr}");
+    assert!(
+        format!("{stdout}{stderr}").contains("even though"),
+        "forced removal should warn about deduplicated use: {stdout}{stderr}"
+    );
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_file_untrack.rs
+++ b/lib/tests/test_file_untrack.rs
@@ -1,0 +1,89 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const CONTENT: &str = "Oh, data, my, data\n";
+
+fn setup() -> Result<XvcRoot> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), CONTENT)?;
+    Ok(xvc_root)
+}
+
+fn is_symlink(path: &Path) -> bool {
+    path.symlink_metadata()
+        .map(|md| md.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_file_untrack() -> Result<()> {
+    let xvc_root = setup()?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["file"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+    let p = |s: &str| xvc_root.join(&PathBuf::from(s));
+
+    // Untracking deletes the cached copy but leaves the workspace file
+    x(&["track", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+    let untrack_out = x(&["untrack", "data.txt"])?;
+    assert!(untrack_out.contains("[DELETE]"), "{untrack_out}");
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+    assert!(p("data.txt").exists());
+    assert_eq!(fs::read_to_string(p("data.txt"))?, CONTENT);
+
+    // Untracking a symlink-rechecked file restores it as a regular file
+    x(&["track", "data.txt", "--as", "symlink"])?;
+    assert!(is_symlink(&p("data.txt")));
+    x(&["untrack", "data.txt"])?;
+    assert!(!is_symlink(&p("data.txt")), "data.txt should be a copy now");
+    assert_eq!(fs::read_to_string(p("data.txt"))?, CONTENT);
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+
+    // --restore-versions copies all cached versions before deleting them
+    x(&["track", "data.txt"])?;
+    fs::write(p("data.txt"), "second version\n")?;
+    x(&["carry-in", "data.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 2);
+    x(&[
+        "untrack",
+        "data.txt",
+        "--restore-versions",
+        "data-versions/",
+    ])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+    let restored: Vec<_> = fs::read_dir(p("data-versions"))?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .collect();
+    assert_eq!(
+        restored.len(),
+        2,
+        "both versions should be restored: {restored:?}"
+    );
+
+    // Deduplicated cache files are only deleted when the last user is untracked
+    fs::write(p("data.txt"), CONTENT)?;
+    x(&["track", "data.txt"])?;
+    x(&["copy", "data.txt", "data2.txt", "--as", "symlink"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+    let untrack_out = x(&["untrack", "data.txt"])?;
+    assert!(
+        untrack_out.contains("also used by"),
+        "should report the other path using the cache file: {untrack_out}"
+    );
+    assert_eq!(cache_paths(&xvc_root).len(), 1);
+    x(&["untrack", "data2.txt"])?;
+    assert_eq!(cache_paths(&xvc_root).len(), 0);
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_pipeline_export_import.rs
+++ b/lib/tests/test_pipeline_export_import.rs
@@ -1,0 +1,119 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::PathBuf;
+
+use xvc::error::Result;
+use xvc_core::XvcVerbosity;
+
+#[test]
+fn test_pipeline_export_import() -> Result<()> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    fs::write(xvc_root.join(&PathBuf::from("data.txt")), "some data\n")?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["pipeline"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+
+    x(&[
+        "step",
+        "new",
+        "--step-name",
+        "step1",
+        "--command",
+        "echo hello",
+    ])?;
+    x(&[
+        "step",
+        "new",
+        "--step-name",
+        "step2",
+        "--command",
+        "echo world",
+        "--when",
+        "always",
+    ])?;
+    x(&["step", "dependency", "-s", "step2", "--step", "step1"])?;
+    x(&["step", "dependency", "-s", "step1", "--file", "data.txt"])?;
+    x(&["step", "dependency", "-s", "step1", "--glob", "data*"])?;
+
+    // step list prints step names with their commands
+    let step_list = x(&["step", "list"])?;
+    assert!(step_list.contains("step1"), "{step_list}");
+    assert!(step_list.contains("echo hello"), "{step_list}");
+    assert!(step_list.contains("step2"), "{step_list}");
+
+    // ... and only the names with --names-only
+    let step_names = x(&["step", "list", "--names-only"])?;
+    assert!(step_names.contains("step1"), "{step_names}");
+    assert!(!step_names.contains("echo hello"), "{step_names}");
+
+    // step show prints the step definition with its dependencies
+    let step_show = x(&["step", "show", "--step-name", "step1"])?;
+    assert!(step_show.contains("step1"), "{step_show}");
+    assert!(step_show.contains("echo hello"), "{step_show}");
+    assert!(step_show.contains("data.txt"), "{step_show}");
+
+    // step update changes the command
+    x(&[
+        "step",
+        "update",
+        "--step-name",
+        "step1",
+        "--command",
+        "echo updated",
+        "--when",
+        "by_dependencies",
+    ])?;
+    let step_show = x(&["step", "show", "--step-name", "step1"])?;
+    assert!(step_show.contains("echo updated"), "{step_show}");
+    assert!(!step_show.contains("echo hello"), "{step_show}");
+
+    // export prints to stdout by default (JSON)
+    let exported = x(&["export"])?;
+    assert!(exported.contains("step1"), "{exported}");
+    assert!(exported.contains("echo updated"), "{exported}");
+
+    // export to files; format is inferred from the extension
+    x(&["export", "--file", "pipeline.json"])?;
+    let json_content = fs::read_to_string(xvc_root.join(&PathBuf::from("pipeline.json")))?;
+    assert!(json_content.contains("step1"), "{json_content}");
+    x(&["export", "--file", "pipeline.yaml"])?;
+    let yaml_content = fs::read_to_string(xvc_root.join(&PathBuf::from("pipeline.yaml")))?;
+    assert!(yaml_content.contains("step1"), "{yaml_content}");
+
+    // importing over an existing pipeline requires --overwrite
+    let (success, stdout, stderr) = run_xvc_unchecked(
+        Some(&xvc_root),
+        &["pipeline", "import", "--file", "pipeline.json"],
+    )?;
+    assert!(
+        !success || format!("{stdout}{stderr}").contains("already"),
+        "import without --overwrite should not overwrite: {stdout}{stderr}"
+    );
+    x(&["import", "--file", "pipeline.json", "--overwrite"])?;
+
+    // import into a new pipeline name
+    x(&[
+        "--pipeline-name",
+        "imported",
+        "import",
+        "--file",
+        "pipeline.yaml",
+    ])?;
+    let pipelines = x(&["list"])?;
+    assert!(pipelines.contains("imported"), "{pipelines}");
+    let imported_steps = x(&["--pipeline-name", "imported", "step", "list"])?;
+    assert!(imported_steps.contains("step1"), "{imported_steps}");
+    assert!(imported_steps.contains("step2"), "{imported_steps}");
+
+    // step remove deletes a step from the pipeline
+    x(&["step", "remove", "--step-name", "step2"])?;
+    let step_list = x(&["step", "list"])?;
+    assert!(!step_list.contains("step2"), "{step_list}");
+    assert!(step_list.contains("step1"), "{step_list}");
+
+    clean_up(&xvc_root)
+}

--- a/lib/tests/test_pipeline_run_deps.rs
+++ b/lib/tests/test_pipeline_run_deps.rs
@@ -1,0 +1,123 @@
+mod common;
+use common::*;
+
+use std::fs;
+use std::path::PathBuf;
+
+use xvc::error::Result;
+use xvc_core::XvcRoot;
+use xvc_core::XvcVerbosity;
+
+const PEOPLE: &str = "Jack,20\nMary,30\nJill,25\nTom,40\n";
+const PEOPLE_CHANGED: &str = "Jack,20\nJune,35\nJill,25\nTom,40\n";
+
+/// Steps append a line to their own log file on each invocation, so the
+/// number of lines in a log shows how many times the step actually ran.
+fn log_lines(xvc_root: &XvcRoot, name: &str) -> usize {
+    let path = xvc_root.join(&PathBuf::from(name));
+    if !path.exists() {
+        return 0;
+    }
+    fs::read_to_string(path)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+#[test]
+fn test_pipeline_run_deps() -> Result<()> {
+    let xvc_root = run_in_temp_xvc_dir()?;
+    let p = |s: &str| xvc_root.join(&PathBuf::from(s));
+    fs::write(p("people.csv"), PEOPLE)?;
+    fs::write(p("generic-input.txt"), "v1\n")?;
+    let x = |cmd: &[&str]| -> Result<String> {
+        let mut c = vec!["pipeline"];
+        c.extend(cmd);
+        run_xvc(Some(&xvc_root), &c, XvcVerbosity::Default)
+    };
+
+    let new_step = |name: &str, log: &str| -> Vec<String> {
+        vec![
+            "step".into(),
+            "new".into(),
+            "--step-name".into(),
+            name.into(),
+            "--command".into(),
+            format!("echo ran >> {log}"),
+        ]
+    };
+    let steps = [
+        ("step_generic", "generic.log"),
+        ("step_lines", "lines.log"),
+        ("step_line_items", "line_items.log"),
+        ("step_regex", "regex.log"),
+        ("step_regex_items", "regex_items.log"),
+    ];
+    for (name, log) in &steps {
+        let args = new_step(name, log);
+        x(&args.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+    }
+
+    x(&[
+        "step",
+        "dependency",
+        "-s",
+        "step_generic",
+        "--generic",
+        "cat generic-input.txt",
+    ])?;
+    x(&[
+        "step",
+        "dependency",
+        "-s",
+        "step_lines",
+        "--lines",
+        "people.csv::1-4",
+    ])?;
+    x(&[
+        "step",
+        "dependency",
+        "-s",
+        "step_line_items",
+        "--line-items",
+        "people.csv::1-4",
+    ])?;
+    x(&[
+        "step",
+        "dependency",
+        "-s",
+        "step_regex",
+        "--regex",
+        "people.csv:/^J",
+    ])?;
+    x(&[
+        "step",
+        "dependency",
+        "-s",
+        "step_regex_items",
+        "--regex-items",
+        "people.csv:/^J",
+    ])?;
+
+    // First run: every step runs once
+    x(&["run"])?;
+    for (_, log) in &steps {
+        assert_eq!(log_lines(&xvc_root, log), 1, "{log} after first run");
+    }
+
+    // Second run without changes: every step is skipped
+    x(&["run"])?;
+    for (_, log) in &steps {
+        assert_eq!(log_lines(&xvc_root, log), 1, "{log} after unchanged run");
+    }
+
+    // Change the dependencies: line 2 changes (within lines 1-4 and matching ^J)
+    // and the generic command output changes
+    fs::write(p("people.csv"), PEOPLE_CHANGED)?;
+    fs::write(p("generic-input.txt"), "v2\n")?;
+    x(&["run"])?;
+    for (_, log) in &steps {
+        assert_eq!(log_lines(&xvc_root, log), 2, "{log} after changed run");
+    }
+
+    clean_up(&xvc_root)
+}


### PR DESCRIPTION
Add Linux-runnable integration tests for commands that were previously
covered only by the macOS-only trycmd doc tests (or not at all):

- xvc file copy: recheck methods, globs, changed-source refusal,
  copying from cache, --no-recheck
- xvc file move: renames, recheck methods, globs, --no-recheck
- xvc file untrack: cache deletion, symlink restore, --restore-versions,
  deduplication handling
- xvc file remove: --from-cache, --only-version, --all-versions,
  deduplication and --force
- xvc file carry-in: new versions, unchanged no-op, --force,
  --text-or-binary
- xvc check-ignore: CLI targets, stdin, whitelist patterns,
  --ignore-filename
- xvc pipeline export/import and step list/show/update/remove
- xvc pipeline run with generic, lines, line-items, regex and
  regex-items dependencies, including skip-on-unchanged and
  re-run-on-change behavior

Also add run_xvc_unchecked and cache_paths helpers to the common test
module.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DBqfAvMgnNGeENLUX3RiZn