### PR TITLE
Configure Dependabot: weekly Wednesday updates, single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering `cargo` (workspace root) and `github-actions`.
- Schedule set to weekly on Wednesdays.
- All packages within each ecosystem are grouped into a single `all-dependencies` PR via a wildcard group, instead of one PR per dependency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNeoVMNcxg4HfNiPMfRt9q)_