### PR TITLE
Add KDL pipeline definition language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Xvc Changelog
 
+## v0.7.1-alpha.4 (2026-07-19)
+
+- Added a KDL-based pipeline definition language (`pipeline export`/`import --format kdl`): pipelines defined as graphs, with `node` children for dependencies and `step` children for the commands that connect them.
+- Bump all package versions to `0.7.1-alpha.4`.
+- Update internal dependencies to match the new version.
+
 ## v0.7.1-alpha.3 (2026-03-31)
 
 - Bump all package versions to `0.7.1-alpha.3`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,16 @@ persist!(MyType, "my-type");  // generates Storable impl; "my-type" becomes the 
 3. Implement `compare_dependency` in `deps/compare.rs`.
 4. Add CLI parsing in `pipeline/src/pipeline/api/` and wire into `cmd_step_dependency`.
 
+### KDL pipeline definitions
+
+`pipeline/src/pipeline/kdl/` converts between KDL documents and `XvcPipelineSchema`, the same schema `pipeline export`/`import` use for JSON and YAML (see `iesahin/xvc-mono`'s `book/src/arch/kdl-pipeline-definition.md` for the language design):
+
+- `kdl/mod.rs` — public interface: `pipeline_schema_from_kdl` / `pipeline_schema_to_kdl`.
+- `kdl/parse.rs` — KDL document -> `XvcPipelineSchema`, building dependencies through the existing constructors (`FileDep::new`, `ParamDep::new`, ...).
+- `kdl/generate.rs` — `XvcPipelineSchema` -> KDL document (the canonical graph form: shared dependencies become shared `node`s).
+
+Tests live in `iesahin/xvc-mono`'s `xvc-test` crate (`test_pipeline_kdl_schema.rs` for parsing/generation, `test_pipeline_kdl.rs` for CLI-level behavior), not in this repo.
+
 ### Recheck methods
 
 `RecheckMethod` controls how files are placed in the workspace from cache: `Copy`, `Symlink`, `Hardlink`, or `Reflink` (feature-gated). Default is `Copy`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2952,6 +2952,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdl"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+dependencies = [
+ "miette",
+ "num",
+ "winnow 0.6.24",
+]
+
+[[package]]
 name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,6 +3135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,10 +3254,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4701,7 +4785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5070,6 +5154,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5654,6 +5744,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -5915,6 +6014,7 @@ dependencies = [
  "glob",
  "hex",
  "itertools 0.15.0",
+ "kdl",
  "lazy_static",
  "log",
  "path-absolutize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,13 +2953,14 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "6.5.0"
+version = "6.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a29e7b50079ff44549f68c0becb1c73d7f6de2a4ea952da77966daf3d4761e"
+checksum = "082ddf81b2acd76fe04412655d17befedfff1837db772f8e74c38050d25ed670"
 dependencies = [
  "miette",
- "num",
- "winnow 0.6.24",
+ "num-traits",
+ "serde",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3254,73 +3255,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -5741,15 +5679,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5709,7 +5709,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xvc"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-config"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-core"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-ecs"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-file"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-logging"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-pipeline"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-storage"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-test-helper"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -6049,7 +6049,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-walker"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging" }
-xvc-walker = { version = "0.7.1-alpha.3", path = "../walker" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
+xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
 
 
 ## Cli and config

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.7.1-alpha.3", path = "../config" }
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging" }
-xvc-ecs = { version = "0.7.1-alpha.3", path = "../ecs" }
-xvc-walker = { version = "0.7.1-alpha.3", path = "../walker" }
+xvc-config = { version = "0.7.1-alpha.4", path = "../config" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
+xvc-ecs = { version = "0.7.1-alpha.4", path = "../ecs" }
+xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -93,6 +93,6 @@ itertools = "^0.15"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
 proptest = "^1.9"
 test-case = "^3.3"

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -25,8 +25,8 @@ bench = true
 # xvc-config = { version = "0.6.17-alpha.2", path = "../config" }
 # xvc-ecs = { version = "0.6.17-alpha.2", path = "../ecs" }
 # xvc-walker = { version = "0.6.17-alpha.2", path = "../walker" }
-xvc-core = { version = "0.7.1-alpha.3", path = "../core" }
-xvc-storage = { version = "0.7.1-alpha.3", path = "../storage", default-features = false }
+xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
+xvc-storage = { version = "0.7.1-alpha.4", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -103,5 +103,5 @@ default = []
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
 shellfn = "^0.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,10 +20,10 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-core = { version = "0.7.1-alpha.3", path = "../core" }
-xvc-file = { version = "0.7.1-alpha.3", path = "../file" }
-xvc-pipeline = { version = "0.7.1-alpha.3", path = "../pipeline" }
-xvc-storage = { version = "0.7.1-alpha.3", path = "../storage", default-features = false }
+xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
+xvc-file = { version = "0.7.1-alpha.4", path = "../file" }
+xvc-pipeline = { version = "0.7.1-alpha.4", path = "../pipeline" }
+xvc-storage = { version = "0.7.1-alpha.4", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo", "unstable-ext"] }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = "^0.11"
 sha3 = "^0.12"
 
 ## Serialization
+kdl = "^6.3"
 serde = { version = "^1.0", features = ["derive"] }
 serde_yaml = "^0.9"
 serde_json = "^1.0"

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,11 +20,11 @@ bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
 # xvc-config = { version = "0.6.17-alpha.2", path = "../config" }
-xvc-core = { version = "0.7.1-alpha.3", path = "../core" }
+xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
 # xvc-ecs = { version = "0.6.17-alpha.2", path = "../ecs" }
 # xvc-logging = { version = "0.6.17-alpha.2", path = "../logging" }
 # xvc-walker = { version = "0.6.17-alpha.2", path = "../walker" }
-xvc-file = { version = "0.7.1-alpha.3", path = "../file", default-features = false }
+xvc-file = { version = "0.7.1-alpha.4", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -101,5 +101,5 @@ itertools = "^0.15"
 derive_more = { version = "^2.1", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
 test-case = "^3.3"

--- a/pipeline/src/error.rs
+++ b/pipeline/src/error.rs
@@ -56,6 +56,9 @@ pub enum Error {
     #[error("Invalid regular expression: {regex}")]
     InvalidRegexFormat { regex: String },
     //
+    #[error("KDL pipeline definition error: {message}")]
+    InvalidKdlPipeline { message: String },
+    //
     #[error("Invalid lines definition: {line}")]
     InvalidLinesFormat { line: String },
     //

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -25,6 +25,7 @@ use pipeline::api::import::ImportCLI;
 use pipeline::api::new::NewCLI;
 use pipeline::api::update::UpdateCLI;
 pub use pipeline::deps;
+pub use pipeline::kdl;
 
 use pipeline::step::StepCLI;
 use pipeline::step::handle_step_cli;

--- a/pipeline/src/pipeline/api/export.rs
+++ b/pipeline/src/pipeline/api/export.rs
@@ -148,6 +148,9 @@ pub fn cmd_export(
             serde_json::to_string_pretty(&value)?
         }
         XvcSchemaSerializationFormat::Yaml => to_yaml(&pipeline_schema)?,
+        XvcSchemaSerializationFormat::Kdl => {
+            crate::pipeline::kdl::pipeline_schema_to_kdl(&pipeline_schema)?
+        }
     };
     match file {
         Some(path) => fs::write(path, export_output).map_err(|e| e.into()),

--- a/pipeline/src/pipeline/api/import.rs
+++ b/pipeline/src/pipeline/api/import.rs
@@ -80,6 +80,9 @@ pub fn cmd_import<R: BufRead>(
     let schema: XvcPipelineSchema = match format {
         XvcSchemaSerializationFormat::Json => serde_json::from_str(&content)?,
         XvcSchemaSerializationFormat::Yaml => serde_yaml::from_str(&content)?,
+        XvcSchemaSerializationFormat::Kdl => {
+            crate::pipeline::kdl::pipeline_schema_from_kdl(&content)?
+        }
     };
 
     assert!(schema.version == 1);

--- a/pipeline/src/pipeline/kdl/generate.rs
+++ b/pipeline/src/pipeline/kdl/generate.rs
@@ -1,0 +1,217 @@
+//! Generate a KDL document from an [`XvcPipelineSchema`].
+use kdl::{KdlDocument, KdlEntry, KdlNode};
+use xvc_core::XvcPath;
+
+use crate::error::Result;
+use crate::pipeline::XvcStepInvalidate;
+use crate::pipeline::schema::{XvcPipelineSchema, XvcStepSchema};
+use crate::{XvcDependency, XvcMetricsFormat, XvcOutput};
+use std::path::Path;
+
+/// The KDL properties defining a dependency and the default node id derived
+/// from its spec text. Step dependencies have no node form (they become
+/// `after`), so they return None.
+fn dep_properties(dep: &XvcDependency) -> Option<(String, Vec<(&'static str, String)>)> {
+    let (id, props) = match dep {
+        XvcDependency::Step(_) => return None,
+        XvcDependency::File(d) => (d.path.to_string(), vec![("file", d.path.to_string())]),
+        XvcDependency::Glob(d) => (d.glob.clone(), vec![("glob", d.glob.clone())]),
+        XvcDependency::GlobItems(d) => (d.glob.clone(), vec![("glob-items", d.glob.clone())]),
+        XvcDependency::Generic(d) => (
+            d.generic_command.clone(),
+            vec![("generic", d.generic_command.clone())],
+        ),
+        XvcDependency::UrlDigest(d) => (d.url.to_string(), vec![("url", d.url.to_string())]),
+        XvcDependency::Param(d) => {
+            let spec = format!("{}::{}", d.path, d.key);
+            (spec.clone(), vec![("param", spec)])
+        }
+        XvcDependency::Regex(d) => {
+            let spec = format!("{}:/{}", d.path, d.regex);
+            (spec.clone(), vec![("regex", spec)])
+        }
+        XvcDependency::RegexItems(d) => {
+            let spec = format!("{}:/{}", d.path, d.regex);
+            (spec.clone(), vec![("regex-items", spec)])
+        }
+        XvcDependency::Lines(d) => {
+            let spec = lines_spec(&d.path, d.begin, d.end);
+            (spec.clone(), vec![("lines", spec)])
+        }
+        XvcDependency::LineItems(d) => {
+            let spec = lines_spec(&d.path, d.begin, d.end);
+            (spec.clone(), vec![("line-items", spec)])
+        }
+        XvcDependency::SqliteQueryDigest(d) => (
+            d.path.to_string(),
+            vec![
+                ("sqlite-file", d.path.to_string()),
+                ("sqlite-query", d.query.clone()),
+            ],
+        ),
+    };
+    Some((id, props))
+}
+
+fn lines_spec(path: &XvcPath, begin: usize, end: usize) -> String {
+    if end == usize::MAX {
+        format!("{path}::{begin}-")
+    } else {
+        format!("{path}::{begin}-{end}")
+    }
+}
+
+/// A dependency node collected for the top of the document. Distinct
+/// dependencies sharing a default id (e.g. a `glob` and a `glob-items` with
+/// the same pattern) get the type appended to disambiguate.
+struct DepNode {
+    id: String,
+    props: Vec<(&'static str, String)>,
+}
+
+/// Render the pipeline schema as a KDL document, the inverse of
+/// [`super::pipeline_schema_from_kdl`]. Runtime bookkeeping (digests,
+/// metadata) is not represented in KDL and is dropped.
+pub fn pipeline_schema_to_kdl(schema: &XvcPipelineSchema) -> Result<String> {
+    let mut nodes = Vec::<DepNode>::new();
+    // node ids per (step index, dependency index), None for step deps
+    let mut dep_ids = Vec::<Vec<Option<String>>>::new();
+
+    for step in &schema.steps {
+        let mut step_dep_ids = Vec::new();
+        for dep in &step.dependencies {
+            step_dep_ids.push(dep_properties(dep).map(|(id, props)| {
+                match nodes.iter().find(|n| n.props == props) {
+                    Some(existing) => existing.id.clone(),
+                    None => {
+                        let id = if nodes.iter().any(|n| n.id == id) {
+                            format!("{} ({})", id, props[0].0)
+                        } else {
+                            id
+                        };
+                        nodes.push(DepNode {
+                            id: id.clone(),
+                            props,
+                        });
+                        id
+                    }
+                }
+            }));
+        }
+        dep_ids.push(step_dep_ids);
+    }
+
+    let mut pipeline = KdlNode::new("pipeline");
+    pipeline
+        .entries_mut()
+        .push(KdlEntry::new(schema.name.clone()));
+    let children = pipeline.ensure_children();
+
+    if schema.workdir != XvcPath::root_path()? {
+        let mut workdir = KdlNode::new("workdir");
+        workdir
+            .entries_mut()
+            .push(KdlEntry::new(schema.workdir.to_string()));
+        children.nodes_mut().push(workdir);
+    }
+
+    for dep_node in &nodes {
+        let mut node = KdlNode::new("node");
+        node.entries_mut().push(KdlEntry::new(dep_node.id.clone()));
+        for (name, value) in &dep_node.props {
+            node.entries_mut()
+                .push(KdlEntry::new_prop(*name, value.clone()));
+        }
+        children.nodes_mut().push(node);
+    }
+
+    for (step, step_dep_ids) in schema.steps.iter().zip(&dep_ids) {
+        children.nodes_mut().push(step_node(step, step_dep_ids));
+    }
+
+    let mut doc = KdlDocument::new();
+    doc.nodes_mut().push(pipeline);
+    doc.autoformat();
+    Ok(doc.to_string())
+}
+
+fn step_node(step: &XvcStepSchema, dep_ids: &[Option<String>]) -> KdlNode {
+    let mut node = KdlNode::new("step");
+    node.entries_mut().push(KdlEntry::new(step.name.clone()));
+    node.entries_mut()
+        .push(KdlEntry::new_prop("command", step.command.clone()));
+    if step.invalidate != XvcStepInvalidate::default() {
+        node.entries_mut()
+            .push(KdlEntry::new_prop("when", step.invalidate.to_string()));
+    }
+
+    let children = node.ensure_children();
+
+    let node_refs: Vec<&String> = dep_ids.iter().flatten().collect();
+    if !node_refs.is_empty() {
+        let mut deps = KdlNode::new("deps");
+        for id in node_refs {
+            deps.entries_mut().push(KdlEntry::new(id.clone()));
+        }
+        children.nodes_mut().push(deps);
+    }
+
+    let step_deps: Vec<&XvcDependency> = step
+        .dependencies
+        .iter()
+        .filter(|d| matches!(d, XvcDependency::Step(_)))
+        .collect();
+    if !step_deps.is_empty() {
+        let mut after = KdlNode::new("after");
+        for dep in step_deps {
+            if let XvcDependency::Step(step_dep) = dep {
+                after
+                    .entries_mut()
+                    .push(KdlEntry::new(step_dep.name.clone()));
+            }
+        }
+        children.nodes_mut().push(after);
+    }
+
+    if !step.outputs.is_empty() {
+        let mut outs = KdlNode::new("outs");
+        let outs_children = outs.ensure_children();
+        for output in &step.outputs {
+            outs_children.nodes_mut().push(output_node(output));
+        }
+        children.nodes_mut().push(outs);
+    }
+
+    node
+}
+
+fn output_node(output: &XvcOutput) -> KdlNode {
+    match output {
+        XvcOutput::File { path } => {
+            let mut node = KdlNode::new("file");
+            node.entries_mut().push(KdlEntry::new(path.to_string()));
+            node
+        }
+        XvcOutput::Image { path } => {
+            let mut node = KdlNode::new("image");
+            node.entries_mut().push(KdlEntry::new(path.to_string()));
+            node
+        }
+        XvcOutput::Metric { path, format } => {
+            let mut node = KdlNode::new("metric");
+            node.entries_mut().push(KdlEntry::new(path.to_string()));
+            // The format is emitted only when the path alone doesn't imply it.
+            if *format != XvcMetricsFormat::from_path(Path::new(&path.to_string())) {
+                let format_str = match format {
+                    XvcMetricsFormat::CSV => "csv",
+                    XvcMetricsFormat::JSON => "json",
+                    XvcMetricsFormat::TSV => "tsv",
+                    XvcMetricsFormat::Unknown => "unknown",
+                };
+                node.entries_mut()
+                    .push(KdlEntry::new_prop("format", format_str));
+            }
+            node
+        }
+    }
+}

--- a/pipeline/src/pipeline/kdl/generate.rs
+++ b/pipeline/src/pipeline/kdl/generate.rs
@@ -129,7 +129,13 @@ pub fn pipeline_schema_to_kdl(schema: &XvcPipelineSchema) -> Result<String> {
         children.nodes_mut().push(step_node(step, step_dep_ids));
     }
 
+    let mut version = KdlNode::new("version");
+    version
+        .entries_mut()
+        .push(KdlEntry::new(schema.version as i128));
+
     let mut doc = KdlDocument::new();
+    doc.nodes_mut().push(version);
     doc.nodes_mut().push(pipeline);
     doc.autoformat();
     Ok(doc.to_string())

--- a/pipeline/src/pipeline/kdl/mod.rs
+++ b/pipeline/src/pipeline/kdl/mod.rs
@@ -1,0 +1,35 @@
+//! KDL pipeline definition language.
+//!
+//! Converts between [KDL](https://kdl.dev) documents and [`XvcPipelineSchema`],
+//! the same schema `xvc pipeline export` / `import` use for JSON and YAML.
+//! A KDL document describes the pipeline as a graph: `node` children declare
+//! dependencies, `step` children declare the commands that connect them.
+//!
+//! ```kdl
+//! pipeline "train-model" {
+//!     node "images" glob-items="data/images/*"
+//!     node "params" param="params.yaml::train"
+//!
+//!     step "train" command="python src/train.py" when="by_dependencies" {
+//!         deps "images" "params" file="data/train.bin"
+//!         after "preprocess"
+//!         outs {
+//!             file "models/model.pt"
+//!             metric "results/metrics.json"
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Node type properties use the same spec syntax as the corresponding
+//! `xvc pipeline step dependency` flags. Runtime bookkeeping (digests,
+//! metadata) never appears in KDL documents.
+//!
+//! Unit tests for this module live in `iesahin/xvc-mono`'s `xvc-test` crate
+//! (`test_pipeline_kdl_schema.rs`), which path-depends on this crate and can
+//! exercise `pipeline_schema_from_kdl` / `pipeline_schema_to_kdl` directly.
+mod generate;
+mod parse;
+
+pub use generate::pipeline_schema_to_kdl;
+pub use parse::pipeline_schema_from_kdl;

--- a/pipeline/src/pipeline/kdl/parse.rs
+++ b/pipeline/src/pipeline/kdl/parse.rs
@@ -1,0 +1,409 @@
+//! Parse a KDL document into an [`XvcPipelineSchema`].
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::str::FromStr;
+
+use kdl::{KdlDocument, KdlNode, KdlValue};
+use regex::Regex;
+use relative_path::RelativePathBuf;
+use url::Url;
+use xvc_core::XvcPath;
+
+use crate::error::{Error, Result};
+use crate::pipeline::deps::{
+    FileDep, GenericDep, GlobDep, GlobItemsDep, LineItemsDep, LinesDep, ParamDep, RegexDep,
+    RegexItemsDep, SqliteQueryDep, StepDep, UrlDigestDep,
+};
+use crate::pipeline::schema::{XvcPipelineSchema, XvcStepSchema};
+use crate::pipeline::{XvcOutput, XvcStepInvalidate};
+use crate::{XvcDependency, XvcMetricsFormat};
+
+/// Dependency node type properties, shared by `node` declarations and inline
+/// `deps` properties. `sqlite-file`/`sqlite-query` must appear together.
+const NODE_TYPES: &[&str] = &[
+    "file",
+    "glob",
+    "glob-items",
+    "param",
+    "regex",
+    "regex-items",
+    "lines",
+    "line-items",
+    "url",
+    "generic",
+    "sqlite-file",
+    "sqlite-query",
+];
+
+fn err<T>(message: impl Into<String>) -> Result<T> {
+    Err(Error::InvalidKdlPipeline {
+        message: message.into(),
+    })
+}
+
+fn xvc_path(spec: &str) -> XvcPath {
+    XvcPath::from(RelativePathBuf::from(spec))
+}
+
+fn string_value(value: &KdlValue, what: &str) -> Result<String> {
+    match value.as_string() {
+        Some(s) => Ok(s.to_string()),
+        None => err(format!("{what} must be a string, found {value}")),
+    }
+}
+
+/// Parse the KDL text of a pipeline definition into the schema used by
+/// `xvc pipeline import`.
+pub fn pipeline_schema_from_kdl(content: &str) -> Result<XvcPipelineSchema> {
+    let doc = KdlDocument::parse(content).map_err(|e| Error::InvalidKdlPipeline {
+        message: e
+            .diagnostics
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    })?;
+
+    let mut pipeline_node = None;
+    for node in doc.nodes() {
+        match node.name().value() {
+            "version" => match node.get(0).and_then(KdlValue::as_integer) {
+                Some(1) => {}
+                _ => return err("only 'version 1' is supported"),
+            },
+            "pipeline" => {
+                if pipeline_node.replace(node).is_some() {
+                    return err("a KDL pipeline file must contain a single 'pipeline' node");
+                }
+            }
+            other => return err(format!("unexpected top level node '{other}'")),
+        }
+    }
+
+    match pipeline_node {
+        Some(node) => parse_pipeline(node),
+        None => err("no 'pipeline' node found"),
+    }
+}
+
+fn parse_pipeline(pipeline: &KdlNode) -> Result<XvcPipelineSchema> {
+    let name = match pipeline.get(0) {
+        Some(v) => string_value(v, "pipeline name")?,
+        None => return err("'pipeline' requires a name argument"),
+    };
+
+    let mut workdir = XvcPath::root_path()?;
+    // Node declarations by id; BTreeMap is enough as steps refer by name.
+    let mut nodes = BTreeMap::<String, XvcDependency>::new();
+    let mut steps = Vec::<XvcStepSchema>::new();
+
+    let children = pipeline
+        .children()
+        .map(KdlDocument::nodes)
+        .unwrap_or_default();
+
+    // Two passes so that steps can reference nodes declared after them.
+    for child in children {
+        match child.name().value() {
+            "workdir" => {
+                let dir = match child.get(0) {
+                    Some(v) => string_value(v, "workdir")?,
+                    None => return err("'workdir' requires a directory argument"),
+                };
+                workdir = xvc_path(&dir);
+            }
+            "node" => {
+                let (id, dep) = parse_node(child)?;
+                if nodes.insert(id.clone(), dep).is_some() {
+                    return err(format!("duplicate node id '{id}'"));
+                }
+            }
+            "step" => {}
+            other => {
+                return err(format!(
+                    "unexpected node '{other}' in pipeline; expected 'workdir', 'node' or 'step'"
+                ));
+            }
+        }
+    }
+
+    for child in children {
+        if child.name().value() == "step" {
+            steps.push(parse_step(child, &nodes)?);
+        }
+    }
+
+    if let Some(step) = steps
+        .iter()
+        .find(|s| steps.iter().filter(|o| o.name == s.name).count() > 1)
+    {
+        return err(format!("duplicate step name '{}'", step.name));
+    }
+
+    Ok(XvcPipelineSchema {
+        version: 1,
+        name,
+        workdir,
+        steps,
+    })
+}
+
+/// Parse a `node "id" <type>="<spec>"` declaration. The id defaults to the
+/// spec text itself.
+fn parse_node(node: &KdlNode) -> Result<(String, XvcDependency)> {
+    let mut id = None;
+    for entry in node.entries() {
+        if entry.name().is_none()
+            && id
+                .replace(string_value(entry.value(), "node id")?)
+                .is_some()
+        {
+            return err("'node' takes a single id argument");
+        }
+    }
+    let (default_id, dep) = parse_dep_properties(node)?;
+    Ok((id.unwrap_or(default_id), dep))
+}
+
+/// Parse the dependency type properties of a `node` or an inline `deps` entry.
+/// Returns the default node id (the spec text) and the dependency.
+fn parse_dep_properties(node: &KdlNode) -> Result<(String, XvcDependency)> {
+    let mut typed = Vec::<(String, String)>::new();
+    for entry in node.entries() {
+        if let Some(name) = entry.name() {
+            let name = name.value();
+            if !NODE_TYPES.contains(&name) {
+                return err(format!(
+                    "unknown dependency type '{name}'; expected one of {}",
+                    NODE_TYPES.join(", ")
+                ));
+            }
+            typed.push((
+                name.to_string(),
+                string_value(entry.value(), &format!("'{name}' value"))?,
+            ));
+        }
+    }
+
+    match typed.as_slice() {
+        [] => err("missing dependency type property"),
+        [(ty, spec)] => Ok((spec.clone(), dep_from_spec(ty, spec)?)),
+        [(ty1, v1), (ty2, v2)] => {
+            // Only the sqlite pair uses two properties.
+            let (file, query) = match (ty1.as_str(), ty2.as_str()) {
+                ("sqlite-file", "sqlite-query") => (v1, v2),
+                ("sqlite-query", "sqlite-file") => (v2, v1),
+                _ => {
+                    return err(format!(
+                        "a dependency takes a single type property, found '{ty1}' and '{ty2}'"
+                    ));
+                }
+            };
+            Ok((
+                file.clone(),
+                XvcDependency::SqliteQueryDigest(SqliteQueryDep::new(
+                    xvc_path(file),
+                    query.clone(),
+                )),
+            ))
+        }
+        _ => err("a dependency takes a single type property"),
+    }
+}
+
+/// Build a dependency from a type name and a spec string. Spec syntaxes are
+/// identical to the corresponding `xvc pipeline step dependency` flags.
+fn dep_from_spec(ty: &str, spec: &str) -> Result<XvcDependency> {
+    let dep = match ty {
+        "sqlite-file" | "sqlite-query" => {
+            return err("sqlite dependencies need both sqlite-file and sqlite-query properties");
+        }
+        "file" => XvcDependency::File(FileDep::new(xvc_path(spec))),
+        "glob" => XvcDependency::Glob(GlobDep::new(spec.to_string())),
+        "glob-items" => XvcDependency::GlobItems(GlobItemsDep::new(spec.to_string())),
+        "generic" => XvcDependency::Generic(GenericDep::new(spec.to_string())),
+        "url" => XvcDependency::UrlDigest(UrlDigestDep::new(Url::parse(spec)?)),
+        "param" => match spec.split_once("::") {
+            Some((file, key)) if !file.is_empty() && !key.is_empty() => {
+                XvcDependency::Param(ParamDep::new(&xvc_path(file), None, key.to_string())?)
+            }
+            _ => return err(format!("param '{spec}' must be in the form 'file::key'")),
+        },
+        "regex" | "regex-items" => {
+            let (file, re) = match spec.split_once(":/") {
+                Some((file, re)) if !file.is_empty() && !re.is_empty() => (file, re),
+                _ => {
+                    return err(format!("{ty} '{spec}' must be in the form 'file:/regex'"));
+                }
+            };
+            if Regex::new(re).is_err() {
+                return Err(Error::InvalidRegexFormat {
+                    regex: re.to_string(),
+                });
+            }
+            if ty == "regex" {
+                XvcDependency::Regex(RegexDep::new(xvc_path(file), re.to_string()))
+            } else {
+                XvcDependency::RegexItems(RegexItemsDep::new(xvc_path(file), re.to_string()))
+            }
+        }
+        "lines" | "line-items" => {
+            let parsed = spec.split_once("::").and_then(|(file, range)| {
+                let (begin, end) = range.split_once('-')?;
+                let begin = if begin.is_empty() {
+                    0
+                } else {
+                    begin.parse().ok()?
+                };
+                let end = if end.is_empty() {
+                    usize::MAX
+                } else {
+                    end.parse().ok()?
+                };
+                Some((file, begin, end))
+            });
+            let (file, begin, end) = match parsed {
+                Some(p) if !p.0.is_empty() => p,
+                _ => {
+                    return err(format!(
+                        "{ty} '{spec}' must be in the form 'file::begin-end'"
+                    ));
+                }
+            };
+            if ty == "lines" {
+                XvcDependency::Lines(LinesDep::new(xvc_path(file), begin, end))
+            } else {
+                XvcDependency::LineItems(LineItemsDep::new(xvc_path(file), begin, end))
+            }
+        }
+        _ => unreachable!("checked against NODE_TYPES"),
+    };
+    Ok(dep)
+}
+
+fn parse_step(step: &KdlNode, nodes: &BTreeMap<String, XvcDependency>) -> Result<XvcStepSchema> {
+    let name = match step.get(0) {
+        Some(v) => string_value(v, "step name")?,
+        None => return err("'step' requires a name argument"),
+    };
+
+    let command = match step.get("command") {
+        Some(v) => string_value(v, "step command")?,
+        None => return err(format!("step '{name}' requires a command property")),
+    };
+
+    let invalidate = match step.get("when") {
+        Some(v) => {
+            let when = string_value(v, "step when")?;
+            XvcStepInvalidate::from_str(&when.replace('-', "_")).map_err(|_| {
+                Error::InvalidKdlPipeline {
+                    message: format!(
+                        "step '{name}': when=\"{when}\" must be one of by_dependencies, always, never"
+                    ),
+                }
+            })?
+        }
+        None => XvcStepInvalidate::default(),
+    };
+
+    for entry in step.entries() {
+        match entry.name().map(|n| n.value()) {
+            None | Some("command") | Some("when") => {}
+            Some(other) => {
+                return err(format!("step '{name}': unknown property '{other}'"));
+            }
+        }
+    }
+
+    let mut dependencies = Vec::<XvcDependency>::new();
+    let mut outputs = Vec::<XvcOutput>::new();
+
+    let children = step.children().map(KdlDocument::nodes).unwrap_or_default();
+    for child in children {
+        match child.name().value() {
+            "deps" => {
+                for entry in child.entries() {
+                    if entry.name().is_none() {
+                        // Argument: a reference to a declared node.
+                        let id = string_value(entry.value(), "deps node reference")?;
+                        match nodes.get(&id) {
+                            Some(dep) => dependencies.push(dep.clone()),
+                            None => {
+                                return err(format!("step '{name}' references unknown node '{id}'"));
+                            }
+                        }
+                    }
+                }
+                // Properties: anonymous inline nodes.
+                if child.entries().iter().any(|e| e.name().is_some()) {
+                    let (_, dep) = parse_dep_properties(child)?;
+                    dependencies.push(dep);
+                }
+            }
+            "after" => {
+                for entry in child.entries() {
+                    let step_name = string_value(entry.value(), "after step name")?;
+                    dependencies.push(XvcDependency::Step(StepDep::new(step_name)));
+                }
+            }
+            "outs" => {
+                let outs_children = child.children().map(KdlDocument::nodes).unwrap_or_default();
+                for out in outs_children {
+                    outputs.push(parse_output(&name, out)?);
+                }
+            }
+            other => {
+                return err(format!(
+                    "step '{name}': unexpected child '{other}'; expected 'deps', 'after' or 'outs'"
+                ));
+            }
+        }
+    }
+
+    Ok(XvcStepSchema {
+        name,
+        command,
+        invalidate,
+        dependencies,
+        outputs,
+    })
+}
+
+fn parse_output(step_name: &str, out: &KdlNode) -> Result<XvcOutput> {
+    let kind = out.name().value();
+    let path_str = match out.get(0) {
+        Some(v) => string_value(v, "output path")?,
+        None => {
+            return err(format!(
+                "step '{step_name}': '{kind}' output requires a path"
+            ));
+        }
+    };
+    let path = xvc_path(&path_str);
+    let output = match kind {
+        "file" => XvcOutput::File { path },
+        "image" => XvcOutput::Image { path },
+        "metric" => {
+            let format = match out.get("format") {
+                Some(v) => match string_value(v, "metric format")?.to_lowercase().as_str() {
+                    "csv" => XvcMetricsFormat::CSV,
+                    "json" => XvcMetricsFormat::JSON,
+                    "tsv" => XvcMetricsFormat::TSV,
+                    other => {
+                        return err(format!(
+                            "step '{step_name}': metric format '{other}' must be csv, json or tsv"
+                        ));
+                    }
+                },
+                None => XvcMetricsFormat::from_path(Path::new(&path_str)),
+            };
+            XvcOutput::Metric { path, format }
+        }
+        other => {
+            return err(format!(
+                "step '{step_name}': unknown output type '{other}'; expected file, metric or image"
+            ));
+        }
+    };
+    Ok(output)
+}

--- a/pipeline/src/pipeline/kdl/parse.rs
+++ b/pipeline/src/pipeline/kdl/parse.rs
@@ -329,7 +329,9 @@ fn parse_step(step: &KdlNode, nodes: &BTreeMap<String, XvcDependency>) -> Result
                         match nodes.get(&id) {
                             Some(dep) => dependencies.push(dep.clone()),
                             None => {
-                                return err(format!("step '{name}' references unknown node '{id}'"));
+                                return err(format!(
+                                    "step '{name}' references unknown node '{id}'"
+                                ));
                             }
                         }
                     }

--- a/pipeline/src/pipeline/mod.rs
+++ b/pipeline/src/pipeline/mod.rs
@@ -2,6 +2,7 @@
 pub mod api;
 pub mod command;
 pub mod deps;
+pub mod kdl;
 pub mod outs;
 pub mod schema;
 pub mod step;

--- a/pipeline/src/pipeline/schema.rs
+++ b/pipeline/src/pipeline/schema.rs
@@ -14,6 +14,7 @@ use super::XvcStepInvalidate;
 pub enum XvcSchemaSerializationFormat {
     Json,
     Yaml,
+    Kdl,
     // Turned off because of UnsupportedType error
     // TOML,
 }
@@ -23,6 +24,7 @@ impl XvcSchemaSerializationFormat {
         match ext.to_str().unwrap_or("") {
             "json" | "JSON" => Ok(Self::Json),
             "yaml" | "yml" => Ok(Self::Yaml),
+            "kdl" | "KDL" => Ok(Self::Kdl),
             // "toml" | "tom" | "tml" => Ok(Self::TOML),
             _ => Err(Error::CannotInferFormatFromExtension {
                 extension: ext.into(),

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging" }
-xvc-config = { version = "0.7.1-alpha.3", path = "../config" }
-xvc-core = { version = "0.7.1-alpha.3", path = "../core" }
-xvc-ecs = { version = "0.7.1-alpha.3", path = "../ecs" }
-xvc-walker = { version = "0.7.1-alpha.3", path = "../walker" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
+xvc-config = { version = "0.7.1-alpha.4", path = "../config" }
+xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
+xvc-ecs = { version = "0.7.1-alpha.4", path = "../ecs" }
+xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -112,7 +112,7 @@ rclone = []
 bundled-rclone = ["rclone", "librclone"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.3", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
 shellfn = "^0.2"
 
 [package.metadata.cargo-udeps.ignore]

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Test helper command for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging/" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging/" }
 
 rand = "^0.10"
 log = "^0.4"

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.7.1-alpha.3"
+version = "0.7.1-alpha.4"
 edition = "2024"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.3", path = "../logging" }
+xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
 # NOTE: 1.0 removed the multi-pattern Glob struct; it's reimplemented in src/glob.rs
 fast-glob = "^1.0"
 
@@ -42,7 +42,7 @@ itertools = "^0.15"
 regex = "^1.12"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.7.1-alpha.3" }
+xvc-test-helper = { path = "../test_helper/", version = "0.7.1-alpha.4" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
## Summary

Implements the KDL pipeline definition language designed in [xvc-mono#15](https://github.com/iesahin/xvc-mono/pull/15): pipelines defined and modified as graphs, where `node` children declare dependencies and `step` children declare the commands that connect them.

```kdl
version 1

pipeline "train-model" {
    node "images" glob-items="data/images/*"
    node "params" param="params.yaml::train"

    step "train" command="python src/train.py" when="by_dependencies" {
        deps "images" "params" file="data/train.bin"
        after "preprocess"
        outs {
            file "models/model.pt"
            metric "results/metrics.json"
        }
    }
}
```

## Design

- One deep adapter module (`pipeline/src/pipeline/kdl/`) with a two-function interface: `pipeline_schema_from_kdl` / `pipeline_schema_to_kdl` over the existing `XvcPipelineSchema`. DAG execution, ECS stores, and all other pipeline commands are untouched.
- Integrated via `pipeline export` / `import` through a new `XvcSchemaSerializationFormat::Kdl` variant recognized by the `.kdl` extension; `import --overwrite` is the modify workflow. No new subcommands.
- All 12 dependency types are supported with the same spec syntax as the `step dependency` CLI flags; step dependencies are written as `after`, outputs (file/metric/image) as `outs` children. Runtime bookkeeping (digests, metadata) never appears in KDL documents.
- A top-level `version` field (defaults to `1`) is reserved for future incompatible language changes.
- Export emits the canonical graph form — one named `node` per distinct dependency, shared across steps — and round-trips through import.

## Commits (Tidy First)

1. Structural: `Kdl` format variant, `InvalidKdlPipeline` error, `kdl` crate dependency.
2. Behavior: parser and generator, export/import wiring.
3. Review follow-up: emit `version 1` in generated output, document the module in `CLAUDE.md`.
4. Unpin `kdl` back to latest now that a newer rustc is available (see below).

## Testing

All KDL-specific tests live in xvc-mono's `xvc-test` crate (which path-depends on this crate), not in this repo, so this PR only carries implementation code:

- `test_pipeline_kdl_schema.rs`: parsing (every node type, defaults, inline deps, open line ranges), generation (node sharing, id disambiguation), round-trip, and 10 error cases — calling `pipeline_schema_from_kdl`/`pipeline_schema_to_kdl` directly.
- `test_pipeline_kdl.rs`: CLI-level integration — define/export/round-trip, modify with `--overwrite`, run with dependency ordering and re-run on change, equivalence with a CLI-built pipeline, parse error reporting.

Both pass against this branch. `cargo build --workspace`, `cargo test --workspace`, and `cargo clippy --workspace` are clean.

## Rebased onto current `main`

This branch is now rebased onto the current `main` tip (previously it lagged three commits behind an unrelated `fast-glob` breakage that #312 has since fixed). Along the way I found the sandbox's pinned rustc (1.94.1) is below `rusqlite`'s and `kdl`'s current MSRV; updating to the latest stable (1.97.1) resolved that without needing to pin either dependency, and the full workspace builds, tests, and lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCrpr1wcj9YDe9NpKoYZUu