### PR TITLE
Upgrade all workspace crates to Rust 2024 edition

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-config"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/config/src/configuration.rs
+++ b/config/src/configuration.rs
@@ -23,7 +23,9 @@ pub struct CoreConfig {
 
 /// Git integration configuration for Xvc.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[display("GitConfig(use_git: {use_git}, command: {command}, auto_commit: {auto_commit}, auto_stage: {auto_stage})")]
+#[display(
+    "GitConfig(use_git: {use_git}, command: {command}, auto_commit: {auto_commit}, auto_stage: {auto_stage})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct GitConfig {
     /// Whether to use Git for version control.
@@ -47,7 +49,9 @@ pub struct CacheConfig {
 
 /// Configuration for file tracking operations.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[display("FileTrackConfig(no_commit: {no_commit}, force: {force}, text_or_binary: {text_or_binary}, no_parallel: {no_parallel}, include_git_files: {include_git_files})")]
+#[display(
+    "FileTrackConfig(no_commit: {no_commit}, force: {force}, text_or_binary: {text_or_binary}, no_parallel: {no_parallel}, include_git_files: {include_git_files})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct FileTrackConfig {
     /// Whether to skip committing changes after tracking.
@@ -64,7 +68,9 @@ pub struct FileTrackConfig {
 
 /// Configuration for file listing operations.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[display("FileListConfig(format: {format}, sort: {sort}, show_dot_files: {show_dot_files}, no_summary: {no_summary}, recursive: {recursive}, include_git_files: {include_git_files})")]
+#[display(
+    "FileListConfig(format: {format}, sort: {sort}, show_dot_files: {show_dot_files}, no_summary: {no_summary}, recursive: {recursive}, include_git_files: {include_git_files})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct FileListConfig {
     /// The format string for displaying file list entries.
@@ -119,7 +125,9 @@ pub struct FileConfig {
 
 /// Configuration for pipeline operations.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[display("PipelineConfig(current_pipeline: {current_pipeline}, default: {default}, default_params_file: {default_params_file}, process_pool_size: {process_pool_size})")]
+#[display(
+    "PipelineConfig(current_pipeline: {current_pipeline}, default: {default}, default_params_file: {default_params_file}, process_pool_size: {process_pool_size})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct PipelineConfig {
     /// The name of the currently active pipeline.
@@ -143,7 +151,9 @@ pub struct CheckIgnoreConfig {
 
 /// The top-level Xvc configuration structure.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[display("XvcConfiguration(core: {core}, git: {git}, cache: {cache}, file: {file}, pipeline: {pipeline}, check_ignore: {check_ignore})")]
+#[display(
+    "XvcConfiguration(core: {core}, git: {git}, cache: {cache}, file: {file}, pipeline: {pipeline}, check_ignore: {check_ignore})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct XvcConfiguration {
     /// Core Xvc settings.
@@ -177,7 +187,9 @@ pub struct OptionalCoreConfig {
 
 /// Optional Git integration configuration for Xvc, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("OptionalGitConfig(use_git: {use_git:?}, command: {command:?}, auto_commit: {auto_commit:?}, auto_stage: {auto_stage:?})")]
+#[display(
+    "OptionalGitConfig(use_git: {use_git:?}, command: {command:?}, auto_commit: {auto_commit:?}, auto_stage: {auto_stage:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct OptionalGitConfig {
     /// Optional setting for whether to use Git for version control.
@@ -201,7 +213,9 @@ pub struct OptionalCacheConfig {
 
 /// Optional configuration for file tracking operations, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("OptionalFileTrackConfig(no_commit: {no_commit:?}, force: {force:?}, text_or_binary: {text_or_binary:?}, no_parallel: {no_parallel:?}, include_git_files: {include_git_files:?})")]
+#[display(
+    "OptionalFileTrackConfig(no_commit: {no_commit:?}, force: {force:?}, text_or_binary: {text_or_binary:?}, no_parallel: {no_parallel:?}, include_git_files: {include_git_files:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct OptionalFileTrackConfig {
     /// Optional setting for whether to skip committing changes after tracking.
@@ -218,7 +232,9 @@ pub struct OptionalFileTrackConfig {
 
 /// Optional configuration for file listing operations, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("OptionalFileListConfig(format: {format:?}, sort: {sort:?}, show_dot_files: {show_dot_files:?}, no_summary: {no_summary:?}, recursive: {recursive:?}, include_git_files: {include_git_files:?})")]
+#[display(
+    "OptionalFileListConfig(format: {format:?}, sort: {sort:?}, show_dot_files: {show_dot_files:?}, no_summary: {no_summary:?}, recursive: {recursive:?}, include_git_files: {include_git_files:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct OptionalFileListConfig {
     /// Optional format string for displaying file list entries.
@@ -257,7 +273,9 @@ pub struct OptionalFileRecheckConfig {
 
 /// Optional comprehensive file-related configuration for Xvc, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("OptionalFileConfig(track: {track:?}, list: {list:?}, carry_in: {carry_in:?}, recheck: {recheck:?})")]
+#[display(
+    "OptionalFileConfig(track: {track:?}, list: {list:?}, carry_in: {carry_in:?}, recheck: {recheck:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct OptionalFileConfig {
     /// Optional configuration for `xvc file track`.
@@ -273,7 +291,9 @@ pub struct OptionalFileConfig {
 
 /// Optional configuration for pipeline operations, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("OptionalPipelineConfig(current_pipeline: {current_pipeline:?}, default: {default:?}, default_params_file: {default_params_file:?}, process_pool_size: {process_pool_size:?})")]
+#[display(
+    "OptionalPipelineConfig(current_pipeline: {current_pipeline:?}, default: {default:?}, default_params_file: {default_params_file:?}, process_pool_size: {process_pool_size:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct OptionalPipelineConfig {
     /// Optional name of the currently active pipeline.
@@ -297,7 +317,9 @@ pub struct OptionalCheckIgnoreConfig {
 
 /// The top-level optional Xvc configuration structure, used for partial updates.
 #[derive(Display, Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
-#[display("XvcOptionalConfiguration(core: {core:?}, git: {git:?}, cache: {cache:?}, file: {file:?}, pipeline: {pipeline:?}, check_ignore: {check_ignore:?})")]
+#[display(
+    "XvcOptionalConfiguration(core: {core:?}, git: {git:?}, cache: {cache:?}, file: {file:?}, pipeline: {pipeline:?}, check_ignore: {check_ignore:?})"
+)]
 #[serde(deny_unknown_fields)]
 pub struct XvcOptionalConfiguration {
     /// Optional core Xvc settings.

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -30,11 +30,11 @@ pub mod configuration;
 pub mod error;
 
 pub use config_params::XvcLoadParams;
+pub use configuration::XvcConfiguration;
+pub use configuration::XvcOptionalConfiguration;
 pub use configuration::blank_optional_config;
 pub use configuration::default_config;
 pub use configuration::initial_xvc_configuration_file;
-pub use configuration::XvcConfiguration;
-pub use configuration::XvcOptionalConfiguration;
 
 use directories_next::{BaseDirs, ProjectDirs, UserDirs};
 use lazy_static::lazy_static;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-core"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/core/src/check_ignore/mod.rs
+++ b/core/src/check_ignore/mod.rs
@@ -1,14 +1,14 @@
 //! xvc check ignore CLI handling module
 use crate::error::Result;
 use crate::util::xvcignore::COMMON_IGNORE_PATTERNS;
-use crate::{XvcPath, XvcRoot, XVCIGNORE_FILENAME};
+use crate::{XVCIGNORE_FILENAME, XvcPath, XvcRoot};
 use clap::Parser;
 
 use log::trace;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use xvc_logging::{output, XvcOutputSender};
-use xvc_walker::{build_ignore_patterns, IgnoreRules, MatchResult, WalkOptions};
+use xvc_logging::{XvcOutputSender, output};
+use xvc_walker::{IgnoreRules, MatchResult, WalkOptions, build_ignore_patterns};
 
 // DIFFERENCES from DVC
 // merged --all and --details, they are the same now

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,14 +10,14 @@ pub mod util;
 pub use types::hashalgorithm::HashAlgorithm;
 pub use types::recheckmethod::RecheckMethod;
 
+pub use types::xvcdigest::AttributeDigest;
+pub use types::xvcdigest::XvcDigest;
+pub use types::xvcdigest::XvcDigests;
 pub use types::xvcdigest::content_digest::ContentDigest;
 pub use types::xvcdigest::path_collection_digest::PathCollectionDigest;
 pub use types::xvcdigest::stdout_digest::StdoutDigest;
 pub use types::xvcdigest::url_get_digest::UrlContentDigest;
 pub use types::xvcdigest::xvc_metadata_digest::XvcMetadataDigest;
-pub use types::xvcdigest::AttributeDigest;
-pub use types::xvcdigest::XvcDigest;
-pub use types::xvcdigest::XvcDigests;
 
 pub use types::diff::Diff;
 pub use types::diff::DiffStore;
@@ -34,8 +34,8 @@ pub use types::xvcfiletype::XvcFileType;
 pub use types::xvcmetadata::XvcMetadata;
 pub use types::xvcpath::XvcCachePath;
 pub use types::xvcpath::XvcPath;
-pub use types::xvcroot::find_root;
 pub use types::xvcroot::XvcRoot;
+pub use types::xvcroot::find_root;
 
 pub use error::Error;
 pub use error::Result;
@@ -44,13 +44,13 @@ pub use error::Result;
 pub use xvc_ecs::error::Error as XvcEcsError;
 pub use xvc_ecs::error::Result as XvcEcsResult;
 pub use xvc_ecs::{
-    persist, Event, EventLog, HStore, R11Store, R1NStore, RMNStore, SharedHStore, SharedXStore,
-    Storable, VStore, XvcEntity, XvcStore,
+    Event, EventLog, HStore, R1NStore, R11Store, RMNStore, SharedHStore, SharedXStore, Storable,
+    VStore, XvcEntity, XvcStore, persist,
 };
 
 pub use xvc_logging::{
-    debug, error, info, output, panic, setup_logging, trace, uwo, uwr, warn, watch, XvcOutputLine,
-    XvcOutputSender,
+    XvcOutputLine, XvcOutputSender, debug, error, info, output, panic, setup_logging, trace, uwo,
+    uwr, warn, watch,
 };
 
 pub use xvc_walker as walker;
@@ -58,12 +58,11 @@ pub use xvc_walker::Error as XvcWalkerError;
 pub use xvc_walker::Result as XvcWalkerResult;
 
 pub use xvc_walker::{
+    AbsolutePath, Glob, IgnoreRules, MatchResult, PathEvent, PathSync, WalkOptions,
     content_to_patterns, make_polling_watcher, path_metadata_map_from_file_targets, walk_parallel,
-    walk_serial, AbsolutePath, Glob, IgnoreRules, MatchResult, PathEvent, PathSync, WalkOptions,
+    walk_serial,
 };
 
-pub use xvc_config::error::Error as XvcConfigError;
-pub use xvc_config::error::Result as XvcConfigResult;
 pub use xvc_config::FromConfig;
 pub use xvc_config::UpdateFromConfig;
 pub use xvc_config::XvcConfig;
@@ -72,6 +71,8 @@ pub use xvc_config::XvcConfiguration;
 pub use xvc_config::XvcLoadParams;
 pub use xvc_config::XvcOptionalConfiguration;
 pub use xvc_config::XvcVerbosity;
+pub use xvc_config::error::Error as XvcConfigError;
+pub use xvc_config::error::Result as XvcConfigResult;
 
 pub use xvc_config::blank_optional_config;
 pub use xvc_config::configuration;
@@ -85,8 +86,8 @@ pub use util::git::{
     stash_user_staged_files, unstash_user_staged_files,
 };
 
-pub use util::pmp::XvcPathMetadataProvider;
 pub use util::XvcPathMetadataMap;
+pub use util::pmp::XvcPathMetadataProvider;
 
 /// Channel size for [crossbeam_channel::bounded] used across the library.
 /// TODO: This can be configurable for smaller/larger RAM sizes.

--- a/core/src/root/mod.rs
+++ b/core/src/root/mod.rs
@@ -4,7 +4,7 @@ use crate::types::xvcroot::XvcRoot;
 use clap::Parser;
 
 use relative_path::RelativePath;
-use xvc_logging::{output, XvcOutputSender};
+use xvc_logging::{XvcOutputSender, output};
 
 #[derive(Debug, Parser, Clone)]
 #[command(name = "root")]

--- a/core/src/types/xvcdigest/content_digest.rs
+++ b/core/src/types/xvcdigest/content_digest.rs
@@ -2,7 +2,7 @@
 use crate::types::diff::Diffable;
 use crate::types::hashalgorithm::HashAlgorithm;
 use crate::util::file::is_text_file;
-use crate::{attribute_digest, TextOrBinary, XvcDigest};
+use crate::{TextOrBinary, XvcDigest, attribute_digest};
 
 use std::{fmt::Display, path::Path};
 

--- a/core/src/types/xvcdigest/mod.rs
+++ b/core/src/types/xvcdigest/mod.rs
@@ -10,7 +10,7 @@ use crate::types::hashalgorithm::HashAlgorithm;
 use std::collections::BTreeMap;
 
 use std::{fmt::Display, fs, path::Path};
-use xvc_ecs::{persist, Storable};
+use xvc_ecs::{Storable, persist};
 
 use crate::error::Result;
 use blake2::{Blake2s, Digest};

--- a/core/src/types/xvcdigest/path_collection_digest.rs
+++ b/core/src/types/xvcdigest/path_collection_digest.rs
@@ -1,7 +1,7 @@
 //! Digest of a list of paths, e.g., a glob or a directory.
 use crate::types::diff::Diffable;
 use crate::types::hashalgorithm::HashAlgorithm;
-use crate::{attribute_digest, XvcDigest, XvcMetadata, XvcPath};
+use crate::{XvcDigest, XvcMetadata, XvcPath, attribute_digest};
 use itertools::Itertools;
 
 use crate::error::Result;

--- a/core/src/types/xvcdigest/stdout_digest.rs
+++ b/core/src/types/xvcdigest/stdout_digest.rs
@@ -1,6 +1,6 @@
 //! Digest of a command output.
 use crate::types::hashalgorithm::HashAlgorithm;
-use crate::{attribute_digest, XvcDigest};
+use crate::{XvcDigest, attribute_digest};
 
 use serde::{Deserialize, Serialize};
 

--- a/core/src/types/xvcdigest/url_get_digest.rs
+++ b/core/src/types/xvcdigest/url_get_digest.rs
@@ -1,6 +1,6 @@
 //! Digest from contents of a GET request to a URL.
 use crate::types::hashalgorithm::HashAlgorithm;
-use crate::{attribute_digest, XvcDigest};
+use crate::{XvcDigest, attribute_digest};
 use reqwest::Url;
 
 use crate::error::Result;

--- a/core/src/types/xvcdigest/xvc_metadata_digest.rs
+++ b/core/src/types/xvcdigest/xvc_metadata_digest.rs
@@ -3,9 +3,9 @@ use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::diff::Diffable;
 use crate::Result;
-use crate::{attribute_digest, HashAlgorithm, XvcDigest, XvcMetadata};
+use crate::types::diff::Diffable;
+use crate::{HashAlgorithm, XvcDigest, XvcMetadata, attribute_digest};
 
 /// A short representation of the file metadata that fits into 32 bytes.
 /// This is used to quickly compare metadata of files without individual fields.

--- a/core/src/types/xvcpath.rs
+++ b/core/src/types/xvcpath.rs
@@ -12,7 +12,7 @@ use derive_more::Display as DeriveDisplay;
 use path_absolutize::*;
 use relative_path::{RelativePath, RelativePathBuf};
 use serde::{Deserialize, Serialize};
-use xvc_logging::{info, output, uwr, XvcOutputSender};
+use xvc_logging::{XvcOutputSender, info, output, uwr};
 use xvc_walker::AbsolutePath;
 
 use std::ops::Deref;

--- a/core/src/types/xvcroot.rs
+++ b/core/src/types/xvcroot.rs
@@ -8,9 +8,9 @@ use std::io::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use xvc_config::configuration::merge_configs;
 use xvc_config::configuration::XvcConfiguration;
 use xvc_config::configuration::XvcOptionalConfiguration;
+use xvc_config::configuration::merge_configs;
 use xvc_config::default_config;
 use xvc_config::initial_xvc_configuration_file;
 use xvc_ecs::ecs::timestamp;
@@ -20,12 +20,12 @@ use xvc_walker::AbsolutePath;
 
 use xvc_config::{XvcConfig, XvcLoadParams};
 
-use crate::error::{Error, Result};
 use crate::GITIGNORE_INITIAL_CONTENT;
 use crate::GUID_FILENAME;
+use crate::XVC_DIR;
 use crate::XVCIGNORE_FILENAME;
 use crate::XVCIGNORE_INITIAL_CONTENT;
-use crate::XVC_DIR;
+use crate::error::{Error, Result};
 
 /// The primary data structure for Xvc repository.
 ///

--- a/core/src/util/completer.rs
+++ b/core/src/util/completer.rs
@@ -1,7 +1,7 @@
 //! Completion helpers for commands and options
 use crate::{
-    types::xvcroot::{find_root, XvcRootInner},
     Result, XvcPath,
+    types::xvcroot::{XvcRootInner, find_root},
 };
 use std::{env, ffi::OsStr, path::Path};
 

--- a/core/src/util/file.rs
+++ b/core/src/util/file.rs
@@ -1,6 +1,6 @@
 //! Core file operationscorefil
-use cached::proc_macro::cached;
 use cached::UnboundCache;
+use cached::proc_macro::cached;
 use glob::Pattern as GlobPattern;
 
 use std::fs::{self, Metadata};
@@ -14,17 +14,17 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use xvc_walker::{IgnoreRules, PathMetadata, SharedIgnoreRules, WalkOptions};
 
+use crate::CHANNEL_BOUND;
 use crate::error::Error;
 use crate::error::Result;
-use crate::CHANNEL_BOUND;
 
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{Receiver, Sender, bounded};
 
 use crate::types::{xvcpath::XvcPath, xvcroot::XvcRoot};
 
-use super::pmp::XvcPathMetadataProvider;
-use super::xvcignore::{walk_parallel, COMMON_IGNORE_PATTERNS};
 use super::XvcPathMetadataMap;
+use super::pmp::XvcPathMetadataProvider;
+use super::xvcignore::{COMMON_IGNORE_PATTERNS, walk_parallel};
 
 ///w
 ///

--- a/core/src/util/git.rs
+++ b/core/src/util/git.rs
@@ -3,12 +3,12 @@ use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
 use crate::XvcRoot;
 use subprocess::Exec;
-use xvc_logging::{debug, XvcOutputSender};
+use xvc_logging::{XvcOutputSender, debug};
 
 use crate::{Error, Result};
 use std::path::Path;
 
-use xvc_walker::{build_ignore_patterns, AbsolutePath, IgnoreRules};
+use xvc_walker::{AbsolutePath, IgnoreRules, build_ignore_patterns};
 
 use crate::GIT_DIR;
 

--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -12,10 +12,10 @@ use std::io::{self, Read};
 use std::thread::sleep;
 use std::time::Duration;
 
-use crossbeam_channel::{bounded, Receiver};
+use crossbeam_channel::{Receiver, bounded};
 
 use crate::error::Result;
-use crate::{XvcMetadata, XvcPath, CHANNEL_BOUND};
+use crate::{CHANNEL_BOUND, XvcMetadata, XvcPath};
 
 /// A hashmap to store [XvcMetadata] for [XvcPath]
 pub type XvcPathMetadataMap = HashMap<XvcPath, XvcMetadata>;

--- a/core/src/util/pmp.rs
+++ b/core/src/util/pmp.rs
@@ -5,17 +5,17 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
-use xvc_logging::{error, uwr, XvcOutputSender};
-use xvc_walker::{build_ignore_patterns, make_watcher, IgnoreRules, MatchResult, PathEvent};
+use xvc_logging::{XvcOutputSender, error, uwr};
+use xvc_walker::{IgnoreRules, MatchResult, PathEvent, build_ignore_patterns, make_watcher};
 
 use crate::error::Error;
 use crate::error::Result;
 use crate::util::xvcignore::COMMON_IGNORE_PATTERNS;
-use crate::{XvcFileType, XVCIGNORE_FILENAME};
-use crossbeam_channel::{bounded, RecvError, Select, Sender};
+use crate::{XVCIGNORE_FILENAME, XvcFileType};
+use crossbeam_channel::{RecvError, Select, Sender, bounded};
 
-use crate::types::{xvcpath::XvcPath, xvcroot::XvcRoot};
 use crate::XvcMetadata;
+use crate::types::{xvcpath::XvcPath, xvcroot::XvcRoot};
 
 use super::XvcPathMetadataMap;
 

--- a/core/src/util/store.rs
+++ b/core/src/util/store.rs
@@ -1,8 +1,8 @@
 //! ECS utilities for easy load and save in a repository.
 use crate::error::Result;
 use crate::types::xvcroot::XvcRootInner;
-use xvc_ecs::R11Store;
 use xvc_ecs::R1NStore;
+use xvc_ecs::R11Store;
 use xvc_ecs::RMNStore;
 use xvc_ecs::Storable;
 use xvc_ecs::XvcStore;

--- a/core/src/util/xvcignore.rs
+++ b/core/src/util/xvcignore.rs
@@ -1,14 +1,14 @@
 //! Walkers with Xvc-specific ignore rules
 use crate::types::{xvcpath::XvcPath, xvcroot::XvcRoot};
 
-use crate::{XvcMetadata, XvcPathMetadataMap, CHANNEL_BOUND, XVCIGNORE_FILENAME};
+use crate::{CHANNEL_BOUND, XVCIGNORE_FILENAME, XvcMetadata, XvcPathMetadataMap};
 
 use crate::error::{Error, Result};
-use crossbeam_channel::{bounded, Sender};
+use crossbeam_channel::{Sender, bounded};
 
 use std::sync::{Arc, RwLock};
 use std::thread;
-use xvc_logging::{warn, XvcOutputSender};
+use xvc_logging::{XvcOutputSender, warn};
 use xvc_walker::{self, IgnoreRules, PathMetadata, WalkOptions};
 use xvc_walker::{Result as XvcWalkerResult, SharedIgnoreRules};
 

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-ecs"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/ecs/src/ecs/mod.rs
+++ b/ecs/src/ecs/mod.rs
@@ -16,13 +16,13 @@ pub mod storable;
 pub mod vstore;
 pub mod xvcstore;
 
-use rand::{rngs, RngCore, SeedableRng};
+use rand::{RngCore, SeedableRng, rngs};
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Once;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 

--- a/ecs/src/ecs/r11store.rs
+++ b/ecs/src/ecs/r11store.rs
@@ -3,8 +3,8 @@
 //! It doesn't have any semantics except binding two components with a single entity.
 use std::path::Path;
 
-use crate::{error::Result, XvcStore};
 use crate::{Storable, XvcEntity};
+use crate::{XvcStore, error::Result};
 use std::fmt::Debug;
 
 /// Associates two [XvcStore]s with two different type of components with a single [XvcEntity].

--- a/ecs/src/ecs/rmnstore.rs
+++ b/ecs/src/ecs/rmnstore.rs
@@ -11,8 +11,8 @@
 use std::fmt::Debug;
 use std::path::Path;
 
-use crate::error::Result;
 use crate::ChildEntity;
+use crate::error::Result;
 use crate::{Storable, XvcStore};
 
 /// RMNStore is M-N RelationStore, where we store arbitrary relationships between two entities. It

--- a/ecs/src/ecs/vstore.rs
+++ b/ecs/src/ecs/vstore.rs
@@ -2,8 +2,8 @@
 //! It's better suited when duplicate elements with the same `XvcEntity` may occur.
 use super::event::{Event, EventLog};
 use super::hstore::HStore;
-use crate::error::{Error, Result};
 use crate::XvcEntity;
+use crate::error::{Error, Result};
 use crate::{Storable, XvcStore};
 use serde::{Deserialize, Serialize};
 

--- a/ecs/src/lib.rs
+++ b/ecs/src/lib.rs
@@ -16,20 +16,20 @@
 pub mod ecs;
 pub mod error;
 
+pub use ecs::XvcEntity;
+pub use ecs::XvcEntityGenerator;
 pub use ecs::hstore::HStore;
 pub use ecs::hstore::SharedHStore;
 pub use ecs::init_generator;
 pub use ecs::load_generator;
-pub use ecs::r11store::R11Store;
 pub use ecs::r1nstore::ChildEntity;
 pub use ecs::r1nstore::R1NStore;
+pub use ecs::r11store::R11Store;
 pub use ecs::rmnstore::RMNStore;
 pub use ecs::storable::Storable;
 pub use ecs::vstore::VStore;
 pub use ecs::xvcstore::SharedXStore;
 pub use ecs::xvcstore::XvcStore;
-pub use ecs::XvcEntity;
-pub use ecs::XvcEntityGenerator;
 
 pub use ecs::event::Event;
 pub use ecs::event::EventLog;

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-file"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/file/src/bring/mod.rs
+++ b/file/src/bring/mod.rs
@@ -9,23 +9,23 @@
 use crate::common::{load_targets_from_store, move_to_cache};
 
 use crate::{
-    recheck::{cmd_recheck, RecheckCLI},
     Result,
+    recheck::{RecheckCLI, cmd_recheck},
 };
 
 use clap::Parser;
 
 use clap_complete::ArgValueCompleter;
 use xvc_core::util::completer::{strum_variants_completer, xvc_path_completer};
-use xvc_core::{debug, error, uwr, warn, XvcOutputSender};
 use xvc_core::{
     ContentDigest, HStore, RecheckMethod, XvcCachePath, XvcFileType, XvcMetadata, XvcRoot, XvcStore,
 };
+use xvc_core::{XvcOutputSender, debug, error, uwr, warn};
 
 use xvc_core::PathSync;
-use xvc_storage::storage::storage_identifier_completer;
 use xvc_storage::XvcStorageEvent;
-use xvc_storage::{storage::get_storage_record, StorageIdentifier, XvcStorageOperations};
+use xvc_storage::storage::storage_identifier_completer;
+use xvc_storage::{StorageIdentifier, XvcStorageOperations, storage::get_storage_record};
 
 /// Bring (download, pull, fetch) files from storage.
 ///

--- a/file/src/carry_in/mod.rs
+++ b/file/src/carry_in/mod.rs
@@ -13,17 +13,17 @@ use std::collections::HashSet;
 use std::fs;
 
 use xvc_core::XvcRoot;
-use xvc_core::{info, uwo, uwr, warn, watch, XvcOutputSender};
 use xvc_core::{ContentDigest, TextOrBinary};
 use xvc_core::{Diff, XvcCachePath};
+use xvc_core::{XvcOutputSender, info, uwo, uwr, warn, watch};
 
 use crate::common::compare::{diff_content_digest, diff_text_or_binary, diff_xvc_path_metadata};
 use crate::common::gitignore::make_ignore_handler;
+use crate::common::{FileTextOrBinary, update_store_records};
 use crate::common::{
     load_targets_from_store, move_xvc_path_to_cache, only_file_targets, recheck_from_cache,
     set_writable, xvc_path_metadata_map_from_disk,
 };
-use crate::common::{update_store_records, FileTextOrBinary};
 use crate::error::Result;
 
 use clap::Parser;

--- a/file/src/common/compare.rs
+++ b/file/src/common/compare.rs
@@ -1,6 +1,6 @@
 //! File comparison utilities.
-use crate::error::Error;
 use crate::Result;
+use crate::error::Error;
 use anyhow::anyhow;
 use crossbeam_channel::{Receiver, Sender};
 
@@ -11,16 +11,16 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::thread::{self, JoinHandle};
 
-use xvc_core::types::xvcdigest::{content_digest::ContentDigest, DIGEST_LENGTH};
+use xvc_core::types::xvcdigest::{DIGEST_LENGTH, content_digest::ContentDigest};
 use xvc_core::{FromConfig, SharedXStore, XvcEcsError};
 
 use xvc_core::{
-    diff_store, Diff, DiffStore, DiffStore2, HashAlgorithm, RecheckMethod, XvcDigest, XvcFileType,
-    XvcMetadata, XvcPath, XvcPathMetadataMap, XvcRoot,
+    Diff, DiffStore, DiffStore2, HashAlgorithm, RecheckMethod, XvcDigest, XvcFileType, XvcMetadata,
+    XvcPath, XvcPathMetadataMap, XvcRoot, diff_store,
 };
 
-use xvc_core::{debug, error, panic, XvcOutputSender};
 use xvc_core::{HStore, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, debug, error, panic};
 
 use super::FileTextOrBinary;
 

--- a/file/src/common/gitignore.rs
+++ b/file/src/common/gitignore.rs
@@ -9,9 +9,9 @@ use std::io::Write;
 use std::thread::JoinHandle;
 use xvc_core::util::git::build_gitignore;
 
-use crate::{Result, CHANNEL_CAPACITY};
-use xvc_core::{debug, error, info, uwr, XvcOutputSender};
+use crate::{CHANNEL_CAPACITY, Result};
 use xvc_core::{AbsolutePath, IgnoreRules, MatchResult};
+use xvc_core::{XvcOutputSender, debug, error, info, uwr};
 use xvc_core::{XvcPath, XvcRoot};
 
 /// Used to signal ignored files and directories to the ignore handler

--- a/file/src/common/mod.rs
+++ b/file/src/common/mod.rs
@@ -21,18 +21,18 @@ use derive_more::{AsRef, Deref, Display, From, FromStr};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use xvc_core::{
-    all_paths_and_metadata, apply_diff, error, get_absolute_git_command, get_git_tracked_files,
-    info, persist,
+    AbsolutePath, ContentDigest, DiffStore, Glob, HStore, HashAlgorithm, PathSync, RecheckMethod,
+    Storable, TextOrBinary, XvcFileType, XvcMetadata, XvcOutputSender, XvcPath, XvcPathMetadataMap,
+    XvcRoot, XvcStore, all_paths_and_metadata, apply_diff, error, get_absolute_git_command,
+    get_git_tracked_files, info, persist,
     types::xvcpath::XvcCachePath,
     util::{file::make_symlink, xvcignore::COMMON_IGNORE_PATTERNS},
-    uwr, warn, AbsolutePath, ContentDigest, DiffStore, Glob, HStore, HashAlgorithm, PathSync,
-    RecheckMethod, Storable, TextOrBinary, XvcFileType, XvcMetadata, XvcOutputSender, XvcPath,
-    XvcPathMetadataMap, XvcRoot, XvcStore,
-};
-use xvc_core::{
-    path_metadata_map_from_file_targets, XvcConfigResult, XvcConfiguration, XvcWalkerError,
+    uwr, warn,
 };
 use xvc_core::{EventLog, FromConfig};
+use xvc_core::{
+    XvcConfigResult, XvcConfiguration, XvcWalkerError, path_metadata_map_from_file_targets,
+};
 
 use self::gitignore::IgnoreOp;
 

--- a/file/src/copy/mod.rs
+++ b/file/src/copy/mod.rs
@@ -3,20 +3,20 @@
 //! It contains [`CopyCLI`] to handle command line options and [`cmd_copy`] to execute the command.
 use std::path::Path;
 
+use crate::Result;
 use crate::common::compare::{diff_content_digest, diff_xvc_path_metadata};
 use crate::common::gitignore::make_ignore_handler;
-use crate::common::{filter_targets_from_store, xvc_path_metadata_map_from_disk, FileTextOrBinary};
+use crate::common::{FileTextOrBinary, filter_targets_from_store, xvc_path_metadata_map_from_disk};
 use crate::error::Error;
-use crate::recheck::{make_recheck_handler, RecheckOperation};
-use crate::Result;
+use crate::recheck::{RecheckOperation, make_recheck_handler};
 use anyhow::anyhow;
 use clap::Parser;
 
 use clap_complete::ArgValueCompleter;
 use xvc_core::util::completer::{strum_variants_completer, xvc_path_completer};
-use xvc_core::{debug, error, XvcOutputSender};
 use xvc_core::{ContentDigest, Diff, RecheckMethod, XvcFileType, XvcMetadata, XvcPath, XvcRoot};
 use xvc_core::{HStore, R11Store, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, debug, error};
 
 /// CLI for `xvc file copy`.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]

--- a/file/src/hash/mod.rs
+++ b/file/src/hash/mod.rs
@@ -15,11 +15,11 @@ use xvc_core::XvcConfig;
 use xvc_core::XvcConfigResult;
 use xvc_core::XvcConfiguration;
 use xvc_core::XvcLoadParams;
-use xvc_core::{output, XvcOutputSender};
 use xvc_core::{
-    util::file::{path_metadata_channel, pipe_filter_path_errors},
     HashAlgorithm, TextOrBinary, XvcRoot,
+    util::file::{path_metadata_channel, pipe_filter_path_errors},
 };
+use xvc_core::{XvcOutputSender, output};
 
 use crate::common::pipe_path_digest;
 

--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -42,18 +42,18 @@ use clap::Subcommand;
 use crossbeam::thread;
 use crossbeam_channel::bounded;
 
-use log::{debug, error, info, warn, LevelFilter};
+use log::{LevelFilter, debug, error, info, warn};
 use std::io;
 use std::io::Write;
 use std::path::PathBuf;
-use xvc_core::types::xvcroot::load_xvc_root;
 use xvc_core::AbsolutePath;
+use xvc_core::CHANNEL_BOUND;
 use xvc_core::XvcLoadParams;
 use xvc_core::XvcRoot;
 use xvc_core::XvcVerbosity;
-use xvc_core::CHANNEL_BOUND;
-use xvc_core::{find_root, setup_logging};
+use xvc_core::types::xvcroot::load_xvc_root;
 use xvc_core::{XvcOutputLine, XvcOutputSender};
+use xvc_core::{find_root, setup_logging};
 
 pub use bring::BringCLI;
 pub use carry_in::CarryInCLI;

--- a/file/src/list/mod.rs
+++ b/file/src/list/mod.rs
@@ -3,9 +3,9 @@
 //! - [ListCLI] defines the command line options
 //! - [cmd_list]  is the entry point to run the command
 
-use crate::common::{load_targets_from_store, targets_from_disk, FileTextOrBinary};
-use crate::error::Error;
 use crate::Result;
+use crate::common::{FileTextOrBinary, load_targets_from_store, targets_from_disk};
+use crate::error::Error;
 use anyhow::anyhow;
 use chrono;
 use clap::Parser;
@@ -20,13 +20,13 @@ use std::str::FromStr;
 use std::time::SystemTime;
 use strum_macros::{Display as EnumDisplay, EnumString, VariantNames};
 use xvc_core::types::xvcdigest::DIGEST_LENGTH;
-use xvc_core::{error, output, XvcOutputSender};
 use xvc_core::{
     ContentDigest, HashAlgorithm, RecheckMethod, XvcConfigResult, XvcFileType, XvcMetadata,
     XvcPath, XvcRoot,
 };
 use xvc_core::{FromConfig, UpdateFromConfig};
 use xvc_core::{HStore, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, error, output};
 
 /// Format specifier for file list columns
 #[derive(Debug, Clone, EnumString, EnumDisplay, PartialEq, Eq)]
@@ -482,7 +482,9 @@ fn add_summary_line(list_rows: &ListRows) -> String {
     let total_cached_size = format_size(Some(list_rows.total_cached_size()));
 
     // TODO: Add a format string to this output similar to files
-    format!("Total #: {total_lines} Workspace Size: {total_actual_size} Cached Size: {total_cached_size}\n")
+    format!(
+        "Total #: {total_lines} Workspace Size: {total_actual_size} Cached Size: {total_cached_size}\n"
+    )
 }
 
 fn sort_list_rows(list_rows: &mut ListRows) {

--- a/file/src/mv/mod.rs
+++ b/file/src/mv/mod.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use xvc_core::util::completer::{strum_variants_completer, xvc_path_completer};
-use xvc_core::{info, uwr, FromConfig, XvcOutputSender};
+use xvc_core::{FromConfig, XvcOutputSender, info, uwr};
 use xvc_core::{HStore, XvcEntity, XvcStore};
 use xvc_core::{RecheckMethod, XvcFileType, XvcMetadata, XvcPath, XvcRoot};
 

--- a/file/src/recheck/mod.rs
+++ b/file/src/recheck/mod.rs
@@ -7,11 +7,11 @@ use std::thread::JoinHandle;
 use std::{fs, thread};
 
 use crate::common::compare::{diff_content_digest, diff_recheck_method, diff_xvc_path_metadata};
-use crate::common::gitignore::{make_ignore_handler, IgnoreOp};
+use crate::common::gitignore::{IgnoreOp, make_ignore_handler};
 use crate::common::{
-    load_targets_from_store, only_file_targets, xvc_path_metadata_map_from_disk, FileTextOrBinary,
+    FileTextOrBinary, load_targets_from_store, only_file_targets, xvc_path_metadata_map_from_disk,
 };
-use crate::{common::recheck_from_cache, Result};
+use crate::{Result, common::recheck_from_cache};
 use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use crossbeam_channel::Sender;
@@ -20,11 +20,11 @@ use xvc_core::{FromConfig, UpdateFromConfig, XvcConfigResult, XvcConfiguration};
 
 use xvc_core::util::completer::{strum_variants_completer, xvc_path_completer};
 use xvc_core::{
-    apply_diff, ContentDigest, Diff, DiffStore, HashAlgorithm, RecheckMethod, XvcCachePath,
-    XvcMetadata, XvcPath, XvcRoot,
+    ContentDigest, Diff, DiffStore, HashAlgorithm, RecheckMethod, XvcCachePath, XvcMetadata,
+    XvcPath, XvcRoot, apply_diff,
 };
-use xvc_core::{error, info, uwr, warn, XvcOutputSender};
 use xvc_core::{HStore, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, error, info, uwr, warn};
 
 /// Check out file from cache by a copy or link
 ///

--- a/file/src/remove/mod.rs
+++ b/file/src/remove/mod.rs
@@ -3,18 +3,18 @@
 //! [`RemoveCLI`] defines the options of the command, and [`cmd_remove`] is the entry point.
 use std::collections::{HashMap, HashSet};
 
-use crate::common::{cache_paths_for_xvc_paths, filter_targets_from_store};
 use crate::Result;
+use crate::common::{cache_paths_for_xvc_paths, filter_targets_from_store};
 
 use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 
+use xvc_core::XvcEntity;
 use xvc_core::types::xvcdigest::DIGEST_LENGTH;
 use xvc_core::util::completer::xvc_path_completer;
-use xvc_core::XvcEntity;
-use xvc_core::{output, uwr, warn, XvcOutputSender};
 use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_core::{XvcOutputSender, output, uwr, warn};
 use xvc_storage::storage::{get_storage_record, storage_identifier_completer};
 use xvc_storage::{StorageIdentifier, XvcStorageOperations};
 

--- a/file/src/send/mod.rs
+++ b/file/src/send/mod.rs
@@ -2,21 +2,21 @@
 //!
 //! - [`cmd_send`] implements the command
 //! - [`SendCLI`] is the command line interface
-use crate::common::load_targets_from_store;
 use crate::Result;
+use crate::common::load_targets_from_store;
 
 use clap::Parser;
 
 use clap_complete::ArgValueCompleter;
-use xvc_core::{error, XvcOutputSender};
 use xvc_core::{
-    util::completer::xvc_path_completer, ContentDigest, XvcCachePath, XvcFileType, XvcMetadata,
-    XvcRoot,
+    ContentDigest, XvcCachePath, XvcFileType, XvcMetadata, XvcRoot,
+    util::completer::xvc_path_completer,
 };
 use xvc_core::{HStore, XvcStore};
+use xvc_core::{XvcOutputSender, error};
 use xvc_storage::{
-    storage::{get_storage_record, storage_identifier_completer},
     StorageIdentifier, XvcStorageOperations,
+    storage::{get_storage_record, storage_identifier_completer},
 };
 
 /// Send (upload) tracked files to storage

--- a/file/src/share/mod.rs
+++ b/file/src/share/mod.rs
@@ -1,18 +1,18 @@
 //!  Share files from S3 compatible storages for a limited time
 
-use crate::{common::load_targets_from_store, error, Result};
+use crate::{Result, common::load_targets_from_store, error};
 use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use humantime;
 use xvc_core::XvcStore;
 use xvc_core::{
-    util::completer::xvc_path_completer, ContentDigest, XvcCachePath, XvcFileType, XvcMetadata,
-    XvcRoot,
+    ContentDigest, XvcCachePath, XvcFileType, XvcMetadata, XvcRoot,
+    util::completer::xvc_path_completer,
 };
-use xvc_core::{uwo, watch, XvcOutputSender};
+use xvc_core::{XvcOutputSender, uwo, watch};
 use xvc_storage::{
-    storage::{get_storage_record, storage_identifier_completer},
     StorageIdentifier, XvcStorageOperations,
+    storage::{get_storage_record, storage_identifier_completer},
 };
 
 /// Share (uploaded and tracked) files from an S3 compatible storage

--- a/file/src/track/mod.rs
+++ b/file/src/track/mod.rs
@@ -12,8 +12,8 @@ use xvc_core::util::completer::strum_variants_completer;
 
 use std::collections::HashSet;
 
-use xvc_core::util::git::build_gitignore;
 use xvc_core::UpdateFromConfig;
+use xvc_core::util::git::build_gitignore;
 use xvc_core::{FromConfig, XvcConfigResult, XvcConfiguration};
 
 use xvc_core::XvcOutputSender;
@@ -26,7 +26,7 @@ use crate::common::compare::{
     diff_content_digest, diff_recheck_method, diff_text_or_binary, diff_xvc_path_metadata,
 };
 use crate::common::gitignore::{update_dir_gitignores, update_file_gitignores};
-use crate::common::{targets_from_disk, update_store_records, FileTextOrBinary};
+use crate::common::{FileTextOrBinary, targets_from_disk, update_store_records};
 use crate::error::Result;
 
 use clap::Parser;
@@ -161,18 +161,15 @@ pub fn cmd_track(
     let xvc_path_diff = xvc_path_metadata_diff.0;
     let xvc_metadata_diff = xvc_path_metadata_diff.1;
 
-    let changed_entities: HashSet<XvcEntity> =
-        xvc_path_diff
-            .iter()
-            .filter_map(|(xe, xpd)| if xpd.changed() { Some(*xe) } else { None })
-            .chain(xvc_metadata_diff.iter().filter_map(|(xe, xpd)| {
-                if xpd.changed() {
-                    Some(*xe)
-                } else {
-                    None
-                }
-            }))
-            .collect();
+    let changed_entities: HashSet<XvcEntity> = xvc_path_diff
+        .iter()
+        .filter_map(|(xe, xpd)| if xpd.changed() { Some(*xe) } else { None })
+        .chain(xvc_metadata_diff.iter().filter_map(
+            |(xe, xpd)| {
+                if xpd.changed() { Some(*xe) } else { None }
+            },
+        ))
+        .collect();
 
     let stored_recheck_method_store = xvc_root.load_store::<RecheckMethod>()?;
     let default_recheck_method = *RecheckMethod::from_config(conf)?;

--- a/file/src/untrack/mod.rs
+++ b/file/src/untrack/mod.rs
@@ -5,10 +5,10 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self};
 use std::path::PathBuf;
 
-use crate::common::gitignore::make_ignore_handler;
-use crate::common::{cache_paths_for_xvc_paths, filter_targets_from_store, FileTextOrBinary};
-use crate::recheck::{make_recheck_handler, RecheckOperation};
 use crate::Result;
+use crate::common::gitignore::make_ignore_handler;
+use crate::common::{FileTextOrBinary, cache_paths_for_xvc_paths, filter_targets_from_store};
+use crate::recheck::{RecheckOperation, make_recheck_handler};
 use clap::Parser;
 
 use clap_complete::ArgValueCompleter;
@@ -17,9 +17,9 @@ use itertools::Itertools;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 
 use xvc_core::util::completer::xvc_path_completer;
-use xvc_core::{debug, output, panic, uwr, XvcOutputSender};
 use xvc_core::{ContentDigest, RecheckMethod, XvcCachePath, XvcMetadata, XvcPath, XvcRoot};
 use xvc_core::{HStore, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, debug, output, panic, uwr};
 
 /// Remove files from tracking and possibly delete them
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, From, Parser)]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/lib/src/cli/mod.rs
+++ b/lib/src/cli/mod.rs
@@ -5,9 +5,9 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::XvcRootOpt;
 use crate::comp;
 use crate::init;
-use crate::XvcRootOpt;
 
 use xvc_core::git_checkout_ref;
 use xvc_core::handle_git_automation;
@@ -20,18 +20,18 @@ use crossbeam::thread;
 use crossbeam_channel::bounded;
 use log::LevelFilter;
 use std::io;
+use xvc_core::XvcOutputSender;
 use xvc_core::types::xvcroot::find_root;
 use xvc_core::types::xvcroot::load_xvc_root;
 use xvc_core::util::completer::git_branch_completer;
 use xvc_core::util::completer::git_reference_completer;
-use xvc_core::XvcOutputSender;
-use xvc_core::{debug, error, uwr, XvcOutputLine};
+use xvc_core::{XvcOutputLine, debug, error, uwr};
 
+use xvc_core::AbsolutePath;
+use xvc_core::CHANNEL_BOUND;
 use xvc_core::check_ignore;
 use xvc_core::root;
 use xvc_core::setup_logging;
-use xvc_core::AbsolutePath;
-use xvc_core::CHANNEL_BOUND;
 use xvc_core::{XvcLoadParams, XvcVerbosity};
 use xvc_file as file;
 use xvc_pipeline as pipeline;

--- a/lib/src/comp/mod.rs
+++ b/lib/src/comp/mod.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use crate::{cli::XvcCLI, Result};
+use crate::{Result, cli::XvcCLI};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
 use clap_complete_nushell::Nushell;

--- a/lib/src/init/mod.rs
+++ b/lib/src/init/mod.rs
@@ -5,16 +5,16 @@ use log::{info, warn};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
+use xvc_core::AbsolutePath;
+use xvc_core::XvcLoadParams;
+use xvc_core::XvcOptionalConfiguration;
+use xvc_core::XvcRoot;
 use xvc_core::blank_optional_config;
 use xvc_core::configuration::OptionalGitConfig;
 use xvc_core::find_root;
 use xvc_core::types::xvcroot::init_xvc_root;
 use xvc_core::util::git::inside_git;
 use xvc_core::watch;
-use xvc_core::AbsolutePath;
-use xvc_core::XvcLoadParams;
-use xvc_core::XvcOptionalConfiguration;
-use xvc_core::XvcRoot;
 use xvc_pipeline;
 
 /// Initialize an Xvc repository

--- a/lib/src/main.rs
+++ b/lib/src/main.rs
@@ -4,7 +4,7 @@ use std::env;
 
 use clap::CommandFactory;
 
-use xvc::{cli::XvcCLI, error::Result, Error};
+use xvc::{Error, cli::XvcCLI, error::Result};
 
 /// The entry point of the `xvc` cli.
 ///
@@ -22,7 +22,9 @@ fn main() -> Result<()> {
         if ran_completion {
             return Ok(());
         } else {
-            eprintln!("Something is broken with completions. Please undefine COMPLETE environment variable (if there is one) and report this.");
+            eprintln!(
+                "Something is broken with completions. Please undefine COMPLETE environment variable (if there is one) and report this."
+            );
             return Err(Error::CompletionError);
         }
     }

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-logging"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::Once;
 /// Debugging macro to print the given expression and its value, with the module, function and line number
 #[macro_export]
 macro_rules! watch {
-    ( $( $x:expr ),* ) => {
+    ( $( $x:expr_2021 ),* ) => {
         // TODO: Use stdout for this and convert all tracing macros to trace!
         {
             $(
@@ -27,12 +27,12 @@ macro_rules! watch {
 /// Either send a [XvcOutputLine::Error] value to the given channel, or log via `log` crate
 #[macro_export]
 macro_rules! error {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::log::error!($fmt $(,$x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
             (&$channel).send(Some($crate::XvcOutputLine::Error(format!($fmt $(, $x)*)))).unwrap();
         }
@@ -42,12 +42,12 @@ macro_rules! error {
 /// Either send [XvcOutputLine::Info] to the given channel, or log via `log` crate
 #[macro_export]
 macro_rules! info {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::log::info!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
             (&$channel).send(Some($crate::XvcOutputLine::Info(format!($fmt $(,$x)*)))).unwrap();
         }
@@ -57,12 +57,12 @@ macro_rules! info {
 /// Either send [XvcOutputLine::Warn] to the given channel, or log via `log` crate
 #[macro_export]
 macro_rules! warn {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::log::warn!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
             (&$channel).send(
                 Some(
@@ -75,12 +75,12 @@ macro_rules! warn {
 /// Either send [XvcOutputLine::Debug] to the given channel, or log via `log` crate
 #[macro_export]
 macro_rules! debug {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::log::debug!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
                     (&$channel).send(Some($crate::XvcOutputLine::Debug(format!($fmt $(, $x)*)))).unwrap();
         }
@@ -90,18 +90,18 @@ macro_rules! debug {
 /// Either send [XvcOutputLine::Trace] to the given channel, or log via `log` crate
 #[macro_export]
 macro_rules! trace {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::log::trace!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr ),* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 ),* ) => {
         {
             (&$channel).send(Some(::xvc_logging::XvcOutputLine::Trace(format!("{} [{}::{}]", format!($fmt $(, $x)*), file!(), line!())))).unwrap();
         }
     };
 
-    ( $( $x:expr ),* ) => {
+    ( $( $x:expr_2021 ),* ) => {
         {
             $(
                ::log::trace!("{}: {}", stringify!($x), format!("{:#?}", $x).replace("\\n", "\n"));
@@ -113,12 +113,12 @@ macro_rules! trace {
 /// Either send [XvcOutputLine::Output] to the given channel, or print to stdout
 #[macro_export]
 macro_rules! output {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             ::std::println!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
             (&$channel).send(Some($crate::XvcOutputLine::Output(format!($fmt $(, $x)*)))).unwrap();
         }
@@ -128,13 +128,13 @@ macro_rules! output {
 /// Either send [XvcOutputLine::Panic] to the given channel, or print to stdout
 #[macro_export]
 macro_rules! panic {
-    ($fmt:literal $(, $x:expr )* ) => {
+    ($fmt:literal $(, $x:expr_2021 )* ) => {
         {
             watch!($fmt $(, $x)*);
             ::std::panic!($fmt $(, $x)*);
         }
     };
-    ( $channel:expr, $fmt:literal $(, $x:expr )* ) => {
+    ( $channel:expr_2021, $fmt:literal $(, $x:expr_2021 )* ) => {
         {
             (&$channel).send(Some($crate::XvcOutputLine::Panic(format!("{} [{}::{}]",
                                                                  format!($fmt $(, $x)*), file!(), line!())))).unwrap();
@@ -163,7 +163,7 @@ macro_rules! tick {
 /// This is mostly to be used in `for_each` blocks, where the error is not propagated.
 #[macro_export]
 macro_rules! uwr {
-    ( $e:expr, $channel:expr ) => {{
+    ( $e:expr_2021, $channel:expr_2021 ) => {{
         match $e {
             Ok(v) => v,
             Err(e) => {
@@ -186,7 +186,7 @@ macro_rules! uwr {
 /// This is mostly to be used in `for_each` blocks, where the error is not propagated.
 #[macro_export]
 macro_rules! uwo {
-    ( $e:expr, $channel:expr ) => {{
+    ( $e:expr_2021, $channel:expr_2021 ) => {{
         match $e {
             Some(v) => v,
             None => {

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-pipeline"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -26,8 +26,8 @@ use pipeline::api::new::NewCLI;
 use pipeline::api::update::UpdateCLI;
 pub use pipeline::deps;
 
-use pipeline::step::handle_step_cli;
 use pipeline::step::StepCLI;
+use pipeline::step::handle_step_cli;
 use pipeline::util::pipeline_name_completer;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
@@ -41,18 +41,18 @@ use xvc_core::XvcStore;
 
 use xvc_core::XvcPath;
 use xvc_core::XvcRoot;
-use xvc_core::{self, persist, XvcEntity};
+use xvc_core::{self, XvcEntity, persist};
 
 use crate::error::{Error, Result};
+use crate::pipeline::XvcStepInvalidate;
 pub use crate::pipeline::command::CommandProcess;
 pub use crate::pipeline::command::XvcStepCommand;
-pub use crate::pipeline::deps::{param::XvcParamFormat, XvcDependency};
+pub use crate::pipeline::deps::{XvcDependency, param::XvcParamFormat};
 pub use crate::pipeline::outs::XvcMetricsFormat;
 pub use crate::pipeline::outs::XvcOutput;
 pub use crate::pipeline::schema::XvcPipelineSchema;
 pub use crate::pipeline::schema::XvcStepSchema;
 pub use crate::pipeline::step::XvcStep;
-use crate::pipeline::XvcStepInvalidate;
 
 pub use crate::pipeline::api::run::RunCLI;
 

--- a/pipeline/src/pipeline/api/dag.rs
+++ b/pipeline/src/pipeline/api/dag.rs
@@ -2,11 +2,11 @@ use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use petgraph::graphmap::DiGraphMap;
-use tabbycat::attributes::{color, label, shape, Color, Shape};
+use tabbycat::attributes::{Color, Shape, color, label, shape};
 use tabbycat::{AttrList, Edge, GraphBuilder, Identity, StmtList};
 use xvc_core::util::completer::strum_variants_completer;
-use xvc_core::{info, output, XvcOutputSender};
 use xvc_core::{HStore, R1NStore, XvcEntity};
+use xvc_core::{XvcOutputSender, info, output};
 use xvc_core::{XvcPath, XvcPathMetadataProvider, XvcRoot};
 
 use std::collections::HashMap;
@@ -19,8 +19,8 @@ use std::path::PathBuf;
 use strum_macros::{Display, EnumString, IntoStaticStr, VariantNames};
 
 use crate::{
-    pipeline::{add_explicit_dependencies, add_implicit_dependencies},
     XvcDependency, XvcOutput, XvcPipeline, XvcPipelineRunDir, XvcStep,
+    pipeline::{add_explicit_dependencies, add_implicit_dependencies},
 };
 
 #[derive(Debug, Clone, Parser)]

--- a/pipeline/src/pipeline/api/export.rs
+++ b/pipeline/src/pipeline/api/export.rs
@@ -5,20 +5,20 @@ use clap_complete::ArgValueCompleter;
 use itertools::Itertools;
 use std::{fs, path::PathBuf};
 
-use xvc_core::{output, XvcOutputSender};
+use xvc_core::{HStore, R1NStore, R11Store, XvcEntity, XvcStore};
+use xvc_core::{XvcOutputSender, output};
 use xvc_core::{
+    XvcPath, XvcRoot,
     util::{
         completer::strum_variants_completer,
         serde::{to_json, to_yaml},
     },
-    XvcPath, XvcRoot,
 };
-use xvc_core::{HStore, R11Store, R1NStore, XvcEntity, XvcStore};
 
 use crate::{
-    pipeline::{schema::XvcSchemaSerializationFormat, XvcStepInvalidate},
     XvcDependency, XvcOutput, XvcPipeline, XvcPipelineRunDir, XvcPipelineSchema, XvcStep,
     XvcStepCommand, XvcStepSchema,
+    pipeline::{XvcStepInvalidate, schema::XvcSchemaSerializationFormat},
 };
 
 #[derive(Debug, Clone, Parser)]

--- a/pipeline/src/pipeline/api/import.rs
+++ b/pipeline/src/pipeline/api/import.rs
@@ -3,13 +3,13 @@ use clap::Parser;
 use clap_complete::ArgValueCompleter;
 use log::warn;
 use std::{fs, io::BufRead, path::PathBuf};
-use xvc_core::{util::completer::strum_variants_completer, XvcRoot};
-use xvc_core::{R11Store, R1NStore};
+use xvc_core::{R1NStore, R11Store};
+use xvc_core::{XvcRoot, util::completer::strum_variants_completer};
 
 use crate::{
-    pipeline::{schema::XvcSchemaSerializationFormat, XvcStepInvalidate},
     XvcDependency, XvcOutput, XvcPipeline, XvcPipelineRunDir, XvcPipelineSchema, XvcStep,
     XvcStepCommand,
+    pipeline::{XvcStepInvalidate, schema::XvcSchemaSerializationFormat},
 };
 
 #[derive(Debug, Clone, Parser)]

--- a/pipeline/src/pipeline/api/list.rs
+++ b/pipeline/src/pipeline/api/list.rs
@@ -3,7 +3,7 @@ use comfy_table::Table;
 
 use xvc_core::R11Store;
 use xvc_core::XvcRoot;
-use xvc_core::{output, XvcOutputSender};
+use xvc_core::{XvcOutputSender, output};
 
 use crate::{XvcPipeline, XvcPipelineRunDir};
 

--- a/pipeline/src/pipeline/api/step_dependency.rs
+++ b/pipeline/src/pipeline/api/step_dependency.rs
@@ -1,8 +1,9 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
 
-use crate::deps::{sqlite_query, LinesDep, RegexDep};
+use crate::deps::{LinesDep, RegexDep, sqlite_query};
 use crate::error::{Error, Result};
+use crate::pipeline::deps::ParamDep;
 use crate::pipeline::deps::file::FileDep;
 use crate::pipeline::deps::generic::GenericDep;
 use crate::pipeline::deps::glob::GlobDep;
@@ -11,14 +12,13 @@ use crate::pipeline::deps::line_items::LineItemsDep;
 use crate::pipeline::deps::regex_items::RegexItemsDep;
 use crate::pipeline::deps::step::StepDep;
 use crate::pipeline::deps::url::UrlDigestDep;
-use crate::pipeline::deps::ParamDep;
 use crate::pipeline::step::StepSubCommand;
 
 use regex::Regex;
 use url::Url;
 use xvc_core::AbsolutePath;
-use xvc_core::{debug, XvcOutputSender};
 use xvc_core::{R1NStore, XvcEntity};
+use xvc_core::{XvcOutputSender, debug};
 use xvc_core::{XvcPath, XvcRoot};
 
 use crate::{XvcDependency, XvcParamFormat, XvcPipeline, XvcStep};

--- a/pipeline/src/pipeline/api/step_list.rs
+++ b/pipeline/src/pipeline/api/step_list.rs
@@ -1,10 +1,10 @@
 use crate::{
-    error::Result, pipeline::XvcStepInvalidate, Error, XvcPipeline, XvcStep, XvcStepCommand,
+    Error, XvcPipeline, XvcStep, XvcStepCommand, error::Result, pipeline::XvcStepInvalidate,
 };
 use itertools::Itertools;
 use xvc_core::XvcRoot;
-use xvc_core::{output, XvcOutputSender};
 use xvc_core::{HStore, R1NStore};
+use xvc_core::{XvcOutputSender, output};
 
 pub fn cmd_step_list(
     output_snd: &XvcOutputSender,

--- a/pipeline/src/pipeline/api/step_new.rs
+++ b/pipeline/src/pipeline/api/step_new.rs
@@ -1,8 +1,8 @@
 use crate::error::{Error, Result};
 use xvc_core::XvcRoot;
-use xvc_core::{R11Store, R1NStore, XvcStore};
+use xvc_core::{R1NStore, R11Store, XvcStore};
 
-use crate::{pipeline::XvcStepInvalidate, XvcPipeline, XvcStep, XvcStepCommand};
+use crate::{XvcPipeline, XvcStep, XvcStepCommand, pipeline::XvcStepInvalidate};
 
 /// Creates a new step
 pub fn cmd_step_new(

--- a/pipeline/src/pipeline/api/step_remove.rs
+++ b/pipeline/src/pipeline/api/step_remove.rs
@@ -1,10 +1,10 @@
 use xvc_core::XvcRoot;
-use xvc_core::{info, XvcOutputSender};
 use xvc_core::{R1NStore, XvcStore};
+use xvc_core::{XvcOutputSender, info};
 
 use crate::{
-    pipeline::XvcStepInvalidate, Result, XvcDependency, XvcOutput, XvcPipeline, XvcStep,
-    XvcStepCommand,
+    Result, XvcDependency, XvcOutput, XvcPipeline, XvcStep, XvcStepCommand,
+    pipeline::XvcStepInvalidate,
 };
 
 /// Remove a step from a pipeline

--- a/pipeline/src/pipeline/api/step_show.rs
+++ b/pipeline/src/pipeline/api/step_show.rs
@@ -1,10 +1,10 @@
 use crate::error::Error;
-use xvc_core::{util::serde::to_json, XvcRoot};
 use xvc_core::{R1NStore, XvcStore};
+use xvc_core::{XvcRoot, util::serde::to_json};
 
 use crate::{
-    pipeline::XvcStepInvalidate, XvcDependency, XvcOutput, XvcPipeline, XvcStep, XvcStepCommand,
-    XvcStepSchema,
+    XvcDependency, XvcOutput, XvcPipeline, XvcStep, XvcStepCommand, XvcStepSchema,
+    pipeline::XvcStepInvalidate,
 };
 
 /// Entry point for `xvc pipeline step show` command.

--- a/pipeline/src/pipeline/api/step_update.rs
+++ b/pipeline/src/pipeline/api/step_update.rs
@@ -2,7 +2,7 @@ use crate::error::Result;
 use xvc_core::XvcRoot;
 use xvc_core::{R11Store, XvcStore};
 
-use crate::{pipeline::XvcStepInvalidate, XvcPipeline, XvcStep, XvcStepCommand};
+use crate::{XvcPipeline, XvcStep, XvcStepCommand, pipeline::XvcStepInvalidate};
 
 /// Entry point for `xvc pipeline step update` command.
 /// Updates the command and invalidation strategy (`when` to run) of the

--- a/pipeline/src/pipeline/api/update.rs
+++ b/pipeline/src/pipeline/api/update.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 use clap::Parser;
-use xvc_core::error::Error as CoreError;
 use xvc_core::R11Store;
+use xvc_core::error::Error as CoreError;
 use xvc_core::{XvcEcsError, XvcPath, XvcRoot};
 
 use crate::{XvcPipeline, XvcPipelineRunDir};

--- a/pipeline/src/pipeline/deps/compare.rs
+++ b/pipeline/src/pipeline/deps/compare.rs
@@ -1,11 +1,11 @@
 //! Compare all different types of dependencies
+use crate::XvcEntity;
 use crate::error::Result;
 use crate::pipeline::StepStateParams;
-use crate::XvcEntity;
 use anyhow::anyhow;
 
-use xvc_core::types::diff::Diffable;
 use xvc_core::XvcPathMetadataMap;
+use xvc_core::types::diff::Diffable;
 
 use xvc_core::{Diff, HashAlgorithm, TextOrBinary, XvcPath, XvcRoot};
 use xvc_core::{HStore, Storable};

--- a/pipeline/src/pipeline/deps/glob_items.rs
+++ b/pipeline/src/pipeline/deps/glob_items.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use xvc_core::persist;
 use xvc_core::types::diff::Diffable;
 use xvc_core::{
-    glob_paths, ContentDigest, Diff, HashAlgorithm, XvcMetadata, XvcPath, XvcPathMetadataProvider,
-    XvcRoot,
+    ContentDigest, Diff, HashAlgorithm, XvcMetadata, XvcPath, XvcPathMetadataProvider, XvcRoot,
+    glob_paths,
 };
 
 /// A path collection where each item is tracked separately.

--- a/pipeline/src/pipeline/deps/mod.rs
+++ b/pipeline/src/pipeline/deps/mod.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 use xvc_core::XvcPathMetadataProvider;
 
 use crate::error::Error;
-use xvc_core::{glob_includes, glob_paths, XvcPath, XvcPathMetadataMap, XvcRoot};
-use xvc_core::{persist, HStore, XvcStore};
+use xvc_core::{HStore, XvcStore, persist};
+use xvc_core::{XvcPath, XvcPathMetadataMap, XvcRoot, glob_includes, glob_paths};
 
 pub use self::file::FileDep;
 pub use self::generic::GenericDep;

--- a/pipeline/src/pipeline/deps/param.rs
+++ b/pipeline/src/pipeline/deps/param.rs
@@ -1,7 +1,7 @@
 //! A parameter dependency is a key-value pair that is extracted from a parameter in YAML,
 //! TOML or JSON file.
-use crate::error::{Error, Result};
 use crate::XvcDependency;
+use crate::error::{Error, Result};
 use serde_json::value::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 use std::ffi::OsString;

--- a/pipeline/src/pipeline/mod.rs
+++ b/pipeline/src/pipeline/mod.rs
@@ -8,8 +8,8 @@ pub mod step;
 pub mod util;
 
 use self::command::XvcStepCommand;
-use self::deps::compare::superficial_compare_dependency;
 use self::deps::XvcDependency;
+use self::deps::compare::superficial_compare_dependency;
 use self::outs::XvcOutput;
 use self::step::XvcStep;
 use anyhow::anyhow;
@@ -24,9 +24,9 @@ use crate::error::{Error, Result};
 use crate::pipeline::command::CommandProcess;
 use crate::{XvcPipeline, XvcPipelineRunDir};
 
-use crossbeam_channel::{bounded, Receiver, Select, Sender};
+use crossbeam_channel::{Receiver, Select, Sender, bounded};
 
-use xvc_core::{debug, error, info, output, trace, uwr, warn, XvcOutputSender};
+use xvc_core::{XvcOutputSender, debug, error, info, output, trace, uwr, warn};
 
 use petgraph::algo::toposort;
 use petgraph::data::Build;
@@ -39,12 +39,12 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 
 use std::sync::{Arc, RwLock};
-use std::thread::{self, sleep, ScopedJoinHandle};
+use std::thread::{self, ScopedJoinHandle, sleep};
 use std::time::Duration;
 use strum_macros::{Display, EnumString, VariantNames};
-use xvc_core::{update_with_actual, Diff, HashAlgorithm, XvcPath, XvcRoot};
+use xvc_core::{Diff, HashAlgorithm, XvcPath, XvcRoot, update_with_actual};
 
-use xvc_core::{persist, HStore, R1NStore, XvcEntity, XvcStore};
+use xvc_core::{HStore, R1NStore, XvcEntity, XvcStore, persist};
 
 use sp::ExitStatus;
 use subprocess as sp;

--- a/pipeline/src/pipeline/mod.rs
+++ b/pipeline/src/pipeline/mod.rs
@@ -908,21 +908,23 @@ fn s_comparing_diffs_and_outputs_f_superficial_diffs_not_changed<'a>(
     // Check if the step dependencies have run
     {
         // Check if there are any step dependencies that we depend and done by running
-        changed = params.step_dependencies.iter().any(|xe| {
-            if let Ok(hstore) = params.current_states.read() {
-                if let Some(s) = hstore.get(xe) {
-                    if matches!(s, XvcStepState::DoneByRunning(_)) {
-                        true
+        changed = params
+            .step_dependencies
+            .iter()
+            .any(|xe| match params.current_states.read() {
+                Ok(hstore) => {
+                    if let Some(s) = hstore.get(xe) {
+                        if matches!(s, XvcStepState::DoneByRunning(_)) {
+                            true
+                        } else {
+                            changed
+                        }
                     } else {
                         changed
                     }
-                } else {
-                    changed
                 }
-            } else {
-                changed
-            }
-        });
+                _ => changed,
+            });
     }
 
     {

--- a/pipeline/src/pipeline/schema.rs
+++ b/pipeline/src/pipeline/schema.rs
@@ -1,8 +1,8 @@
 use std::{ffi::OsStr, path::Path};
 
 use crate::error::{Error, Result};
-use crate::pipeline::deps::XvcDependency;
 use crate::pipeline::XvcOutput;
+use crate::pipeline::deps::XvcDependency;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString, IntoStaticStr, VariantNames};
 use xvc_core::XvcPath;

--- a/pipeline/src/pipeline/step.rs
+++ b/pipeline/src/pipeline/step.rs
@@ -6,19 +6,19 @@ use xvc_core::util::completer::strum_variants_completer;
 
 use crate::error::{Error, Result};
 use crate::{
-    cmd_step_dependency, cmd_step_new, cmd_step_output, cmd_step_show, cmd_step_update, XvcPipeline,
+    XvcPipeline, cmd_step_dependency, cmd_step_new, cmd_step_output, cmd_step_show, cmd_step_update,
 };
 use clap::Parser;
 use sad_machine::state_machine;
 use serde::{Deserialize, Serialize};
 use xvc_core::XvcOutputSender;
 use xvc_core::XvcRoot;
-use xvc_core::{persist, XvcEntity};
+use xvc_core::{XvcEntity, persist};
 
+use super::XvcStepInvalidate;
 use super::api::step_list::cmd_step_list;
 use super::api::step_remove::cmd_step_remove;
 use super::util::step_name_completer;
-use super::XvcStepInvalidate;
 
 /// Step creation, dependency, output commands
 #[derive(Debug, Clone, Parser)]

--- a/pipeline/src/pipeline/util.rs
+++ b/pipeline/src/pipeline/util.rs
@@ -3,7 +3,7 @@ use std::{env, ffi::OsStr};
 use clap_complete::CompletionCandidate;
 use xvc_core::util::completer::load_store_for_completion;
 
-use crate::{error::Error, XvcPipeline, XvcStep};
+use crate::{XvcPipeline, XvcStep, error::Error};
 
 /// Return all pipeline names starting with `prefix`
 pub fn pipeline_name_completer(prefix: &OsStr) -> Vec<CompletionCandidate> {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-storage"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -81,7 +81,9 @@ pub enum Error {
         source: which::Error,
     },
 
-    #[error("Cloud credentials for storage '{storage_name}' not found. Please set ONE of the following pairs of environment variables: {var_pairs:?}")]
+    #[error(
+        "Cloud credentials for storage '{storage_name}' not found. Please set ONE of the following pairs of environment variables: {var_pairs:?}"
+    )]
     CloudCredentialsNotFound {
         storage_name: String,
         var_pairs: Vec<(String, String)>,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -16,15 +16,15 @@ use clap::{Parser, Subcommand};
 
 use clap_complete::ArgValueCompleter;
 use derive_more::Display;
-use storage::{get_storage_record, storage_identifier_completer};
 pub use storage::{
     XvcLocalStorage, XvcStorage, XvcStorageEvent, XvcStorageGuid, XvcStorageOperations,
 };
+use storage::{get_storage_record, storage_identifier_completer};
 
 use xvc_core::XvcStore;
 
 use xvc_core::XvcRoot;
-use xvc_core::{output, XvcOutputSender};
+use xvc_core::{XvcOutputSender, output};
 
 /// Storage (on the cloud) management commands
 #[derive(Debug, Parser, Clone)]

--- a/storage/src/storage/async_common.rs
+++ b/storage/src/storage/async_common.rs
@@ -4,22 +4,23 @@ use std::str::FromStr;
 
 use futures::StreamExt;
 use regex::Regex;
-use s3::creds::Credentials;
 use s3::Bucket;
 use s3::Region;
+use s3::creds::Credentials;
 use tokio::io::AsyncWriteExt;
-use xvc_core::error;
-use xvc_core::info;
-use xvc_core::output;
 use xvc_core::XvcCachePath;
 use xvc_core::XvcOutputSender;
 use xvc_core::XvcRoot;
+use xvc_core::error;
+use xvc_core::info;
+use xvc_core::output;
 
 use crate::Error;
 use crate::Result;
 use crate::XvcStorageGuid;
 use crate::XvcStorageOperations;
 
+use super::XVC_STORAGE_GUID_FILENAME;
 use super::XvcStorageDeleteEvent;
 use super::XvcStorageExpiringShareEvent;
 use super::XvcStorageInitEvent;
@@ -28,7 +29,6 @@ use super::XvcStoragePath;
 use super::XvcStorageReceiveEvent;
 use super::XvcStorageSendEvent;
 use super::XvcStorageTempDir;
-use super::XVC_STORAGE_GUID_FILENAME;
 
 /// Operations for S3 compatible storage services. Each service implements functions in this trait
 /// for xvc file send and xvc file bring commands to work with the common functions.

--- a/storage/src/storage/common_ops.rs
+++ b/storage/src/storage/common_ops.rs
@@ -24,7 +24,7 @@ pub trait XvcStorageOperations {
     /// The init operation is creates a directory with the "short guid" of the Xvc repository and
     /// adds a .xvc-guid file with the guid of the storage.
     fn init(&mut self, output: &XvcOutputSender, xvc_root: &XvcRoot)
-        -> Result<XvcStorageInitEvent>;
+    -> Result<XvcStorageInitEvent>;
 
     /// Used by xvc file list command to list the contents of a directory in the storage.
     fn list(&self, output: &XvcOutputSender, xvc_root: &XvcRoot) -> Result<XvcStorageListEvent>;

--- a/storage/src/storage/gcs.rs
+++ b/storage/src/storage/gcs.rs
@@ -5,7 +5,7 @@ use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::R1NStore;
-use xvc_core::{info, watch, XvcOutputSender};
+use xvc_core::{XvcOutputSender, info, watch};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};

--- a/storage/src/storage/generic.rs
+++ b/storage/src/storage/generic.rs
@@ -6,14 +6,14 @@ use relative_path::RelativePath;
 use serde::{Deserialize, Serialize};
 use subprocess::Exec;
 use xvc_core::R1NStore;
-use xvc_core::{error, info, warn, watch, XvcOutputSender};
 use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_core::{XvcOutputSender, error, info, warn, watch};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent, XvcStorageGuid, XvcStorageOperations};
 
 use super::{
-    XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent, XvcStoragePath,
-    XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir, XVC_STORAGE_GUID_FILENAME,
+    XVC_STORAGE_GUID_FILENAME, XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent,
+    XvcStoragePath, XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir,
 };
 
 /// Entry point for `xvc storage new generic` command. Receives all parameters from the command

--- a/storage/src/storage/local.rs
+++ b/storage/src/storage/local.rs
@@ -9,12 +9,12 @@ use serde::{Deserialize, Serialize};
 
 use xvc_core::R1NStore;
 use xvc_core::XvcRoot;
-use xvc_core::{info, XvcOutputSender};
+use xvc_core::{XvcOutputSender, info};
 
 use super::{
-    XvcCachePath, XvcStorageDeleteEvent, XvcStorageGuid, XvcStorageInitEvent, XvcStorageListEvent,
-    XvcStorageOperations, XvcStoragePath, XvcStorageReceiveEvent, XvcStorageSendEvent,
-    XvcStorageTempDir, XVC_STORAGE_GUID_FILENAME,
+    XVC_STORAGE_GUID_FILENAME, XvcCachePath, XvcStorageDeleteEvent, XvcStorageGuid,
+    XvcStorageInitEvent, XvcStorageListEvent, XvcStorageOperations, XvcStoragePath,
+    XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir,
 };
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 

--- a/storage/src/storage/minio.rs
+++ b/storage/src/storage/minio.rs
@@ -11,8 +11,8 @@ use xvc_core::{XvcCachePath, XvcRoot};
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};
 
-use super::async_common::XvcS3StorageOperations;
 use super::XvcStoragePath;
+use super::async_common::XvcS3StorageOperations;
 
 /// Configure a new Minio remote storage.
 ///

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -379,7 +379,7 @@ pub fn get_storage_record(
 ) -> Result<XvcStorage> {
     let store: XvcStore<XvcStorage> = xvc_root.load_store()?;
     let storage_store = store.filter(|_, r| match identifier {
-        StorageIdentifier::Name(ref n) => match r {
+        StorageIdentifier::Name(n) => match r {
             XvcStorage::Local(r) => r.name == *n,
             XvcStorage::Generic(r) => r.name == *n,
             XvcStorage::Rsync(r) => r.name == *n,
@@ -399,7 +399,7 @@ pub fn get_storage_record(
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(r) => r.name == *n,
         },
-        StorageIdentifier::Uuid(ref id) => match r {
+        StorageIdentifier::Uuid(id) => match r {
             XvcStorage::Local(lr) => lr.guid == (*id).into(),
             XvcStorage::Generic(gr) => gr.guid == (*id).into(),
             XvcStorage::Rsync(r) => r.guid == (*id).into(),

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use uuid::Uuid;
 use xvc_core::AbsolutePath;
-use xvc_core::{error, XvcOutputSender};
+use xvc_core::{XvcOutputSender, error};
 
 use clap_complete::CompletionCandidate;
 
@@ -48,8 +48,8 @@ use crate::{Error, Result, StorageIdentifier};
 
 use relative_path::{RelativePath, RelativePathBuf};
 
-use xvc_core::{persist, XvcStore};
-use xvc_core::{util::completer::load_store_for_completion, XvcCachePath, XvcRoot};
+use xvc_core::{XvcCachePath, XvcRoot, util::completer::load_store_for_completion};
+use xvc_core::{XvcStore, persist};
 
 use self::generic::XvcGenericStorage;
 

--- a/storage/src/storage/r2.rs
+++ b/storage/src/storage/r2.rs
@@ -7,8 +7,8 @@ use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::R1NStore;
-use xvc_core::{error, info, XvcOutputSender};
 use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_core::{XvcOutputSender, error, info};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};

--- a/storage/src/storage/rclone.rs
+++ b/storage/src/storage/rclone.rs
@@ -14,13 +14,13 @@ use xvc_core::AbsolutePath;
 use xvc_core::R1NStore;
 use xvc_core::XvcCachePath;
 use xvc_core::XvcRoot;
-use xvc_core::{error, info, trace, uwr, warn, XvcOutputSender};
+use xvc_core::{XvcOutputSender, error, info, trace, uwr, warn};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent, XvcStorageGuid, XvcStorageOperations};
 
 use super::{
-    XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent, XvcStoragePath,
-    XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir, XVC_STORAGE_GUID_FILENAME,
+    XVC_STORAGE_GUID_FILENAME, XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent,
+    XvcStoragePath, XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir,
 };
 
 /// Add a new Rclone storage to the repository

--- a/storage/src/storage/rsync.rs
+++ b/storage/src/storage/rsync.rs
@@ -6,14 +6,14 @@ use serde::{Deserialize, Serialize};
 use subprocess::{CaptureData, Exec};
 use xvc_core::AbsolutePath;
 use xvc_core::R1NStore;
-use xvc_core::{error, info, trace, uwr, warn, XvcOutputSender};
 use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_core::{XvcOutputSender, error, info, trace, uwr, warn};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent, XvcStorageGuid, XvcStorageOperations};
 
 use super::{
-    XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent, XvcStoragePath,
-    XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir, XVC_STORAGE_GUID_FILENAME,
+    XVC_STORAGE_GUID_FILENAME, XvcStorageDeleteEvent, XvcStorageInitEvent, XvcStorageListEvent,
+    XvcStoragePath, XvcStorageReceiveEvent, XvcStorageSendEvent, XvcStorageTempDir,
 };
 
 /// Entry point for `xvc storage new rsync` command.

--- a/storage/src/storage/s3.rs
+++ b/storage/src/storage/s3.rs
@@ -5,15 +5,15 @@ use s3::creds::Credentials;
 use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::R1NStore;
-use xvc_core::{info, watch, XvcOutputSender};
 use xvc_core::{XvcCachePath, XvcRoot};
+use xvc_core::{XvcOutputSender, info, watch};
 
 use crate::storage::XVC_STORAGE_GUID_FILENAME;
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};
 
-use super::async_common::XvcS3StorageOperations;
 use super::XvcStoragePath;
+use super::async_common::XvcS3StorageOperations;
 
 /// Configure a new Amazon Web Services S3 remote storage.
 ///

--- a/storage/src/storage/wasabi.rs
+++ b/storage/src/storage/wasabi.rs
@@ -6,13 +6,13 @@ use s3::{Bucket, Region};
 use serde::{Deserialize, Serialize};
 use xvc_core::R1NStore;
 use xvc_core::XvcCachePath;
-use xvc_core::{watch, XvcOutputSender};
+use xvc_core::{XvcOutputSender, watch};
 
 use crate::{Error, Result, XvcStorage, XvcStorageEvent};
 use crate::{XvcStorageGuid, XvcStorageOperations};
 
-use super::async_common::XvcS3StorageOperations;
 use super::XvcStoragePath;
+use super::async_common::XvcS3StorageOperations;
 
 /// Configure a new Wasabi remote storage.
 ///

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-test-helper"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Test helper command for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/test_helper/src/lib.rs
+++ b/test_helper/src/lib.rs
@@ -4,11 +4,11 @@
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 use log::LevelFilter;
-use rand::distr::Alphanumeric;
-use rand::rngs::StdRng;
 use rand::Rng;
 use rand::RngCore;
 use rand::SeedableRng;
+use rand::distr::Alphanumeric;
+use rand::rngs::StdRng;
 use std::cmp;
 use std::env;
 use std::fs::OpenOptions;

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xvc-walker"
 version = "0.7.1-alpha.3"
-edition = "2021"
+edition = "2024"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
 license = "GPL-3.0"

--- a/walker/src/lib.rs
+++ b/walker/src/lib.rs
@@ -39,10 +39,10 @@ pub use std::hash::Hash;
 pub use sync::{PathSync, PathSyncSingleton};
 use xvc_logging::warn;
 
-pub use notify::make_polling_watcher;
-pub use notify::make_watcher;
 pub use notify::PathEvent;
 pub use notify::RecommendedWatcher;
+pub use notify::make_polling_watcher;
+pub use notify::make_watcher;
 
 pub use fast_glob::Glob;
 
@@ -270,8 +270,8 @@ mod tests {
     use log::LevelFilter;
     use test_case::test_case;
 
-    use crate::error::Result;
     use crate::AbsolutePath;
+    use crate::error::Result;
     use xvc_test_helper::*;
 
     #[test_case("!mydir/*/file" => matches PatternEffect::Whitelist ; "t1159938339")]

--- a/walker/src/notify.rs
+++ b/walker/src/notify.rs
@@ -5,8 +5,8 @@
 //! It defines [PathEvent] as a simple version of [notify::EventKind].
 //! It defines [PathEventHandler] that handles events from [notify::EventHandler].
 use crate::{
-    error::{Error, Result},
     IgnoreRules, MatchResult,
+    error::{Error, Result},
 };
 pub use notify::{
     Config, Event, EventHandler, PollWatcher, RecommendedWatcher, RecursiveMode, Watcher,
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use xvc_logging::watch;
 
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{Receiver, Sender, bounded};
 use log::{debug, warn};
 
 /// An walker-relevant event for changes in a directory.

--- a/walker/src/pattern.rs
+++ b/walker/src/pattern.rs
@@ -6,7 +6,7 @@ pub use ignore_rules::IgnoreRules;
 pub use std::hash::Hash;
 pub use sync::{PathSync, PathSyncSingleton};
 
-pub use crate::notify::{make_watcher, PathEvent, RecommendedWatcher};
+pub use crate::notify::{PathEvent, RecommendedWatcher, make_watcher};
 
 use std::{fmt::Debug, path::PathBuf};
 

--- a/walker/src/walk_parallel.rs
+++ b/walker/src/walk_parallel.rs
@@ -6,8 +6,8 @@ use crossbeam_channel::Sender;
 use xvc_logging::watch;
 
 use crate::{
-    directory_list, update_ignore_rules, MatchResult, PathMetadata, Result, SharedIgnoreRules,
-    WalkOptions, MAX_THREADS_PARALLEL_WALK,
+    MAX_THREADS_PARALLEL_WALK, MatchResult, PathMetadata, Result, SharedIgnoreRules, WalkOptions,
+    directory_list, update_ignore_rules,
 };
 
 fn walk_parallel_inner(

--- a/walker/src/walk_serial.rs
+++ b/walker/src/walk_serial.rs
@@ -2,11 +2,11 @@
 //! See [`walk_parallel`] for parallel version.
 use std::path::{Path, PathBuf};
 
-use xvc_logging::{debug, error, warn, XvcOutputSender};
+use xvc_logging::{XvcOutputSender, debug, error, warn};
 
 use crate::{
-    build_ignore_patterns, directory_list, pattern::MatchResult, update_ignore_rules, IgnoreRules,
-    PathMetadata, Result, WalkOptions,
+    IgnoreRules, PathMetadata, Result, WalkOptions, build_ignore_patterns, directory_list,
+    pattern::MatchResult, update_ignore_rules,
 };
 
 /// Walk `dir` with `walk_options`, with the given _initial_ `ignore_rules`.


### PR DESCRIPTION
## Summary
- Tidy first: ran `cargo fix --edition` to make `macro_rules!` `expr` fragments explicit (`expr_2021`) and adjust temporary-lifetime-sensitive control flow / redundant `ref` patterns, committed separately with no behavior change under edition 2021.
- Bumped `edition = "2021"` → `"2024"` in all 10 workspace crates (`core`, `config`, `ecs`, `file`, `lib`, `pipeline`, `storage`, `logging`, `walker`, `test_helper`).
- Reformatted with `cargo fmt --all` to match the 2024 style edition defaults (formatting only).

## Test plan
- [x] `cargo build --workspace --all-targets` — clean, no warnings/errors introduced
- [x] `cargo clippy --workspace --all-targets` — no new warnings vs. baseline
- [x] `cargo test --workspace` — identical results to the pre-upgrade baseline (only pre-existing, environment-only failure: `storage::rclone::tests::test_rclone_drive_list`, which requires the `rclone` binary that isn't installed in this sandbox)
- [x] `cargo fmt --all -- --check` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MV5g88NNNHcNwZjvzegpcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV5g88NNNHcNwZjvzegpcn)_