### PR TITLE
Pin rusqlite to 0.39.0 due to unstable macro in 0.40+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,21 +2379,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
 name = "hashlink"
-version = "0.12.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3055,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3996,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.10.0",
  "fallible-iterator",
@@ -4723,7 +4714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -71,7 +71,10 @@ fern = { version = "^0.7", features = ["colored", "meta-logging-in-format"] }
 
 ## sqlite
 ## TODO: Add feature flags for sqlite when bundling needed
-rusqlite = "^0.40"
+## Pinned to 0.39: 0.40+ uses the unstable `cfg_select!` macro (rust-lang/rust#115585)
+## and fails to build on stable Rust. Remove the pin once that lands on stable
+## and rusqlite adopts it in a released, MSRV-compatible way.
+rusqlite = "=0.39.0"
 fallible-iterator = "^0.3"
 
 ## Networking


### PR DESCRIPTION
## Summary

Pin the `rusqlite` dependency to version 0.39.0 to maintain compatibility with stable Rust. Version 0.40 and later use the unstable `cfg_select!` macro, which prevents compilation on stable Rust.

## Changes

- Updated `pipeline/Cargo.toml` to pin `rusqlite` to `=0.39.0` (exact version)
- Added explanatory comments documenting the reason for the pin and the upstream issue (rust-lang/rust#115585)
- Noted that the pin should be removed once the `cfg_select!` macro lands on stable Rust and rusqlite adopts it in a released, MSRV-compatible way

## Details

The `rusqlite` crate is used by the pipeline module for `sqlite-query` dependencies. Version 0.40+ introduced a dependency on an unstable compiler feature that is not available on stable Rust, causing build failures. This pin ensures the project continues to build on stable Rust while the upstream issue is resolved.

https://claude.ai/code/session_019kLezkcRNjzPLEbkJmPZdT