### PR TITLE
Add Dropbox storage backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Xvc Changelog
 
-## Unreleased
+## v0.7.1-alpha.5 (2026-07-21)
 
-- Added Dropbox storage support (`xvc storage new dropbox`). Credentials are read from `DROPBOX_ACCESS_TOKEN` or `XVC_STORAGE_ACCESS_TOKEN_<storage_name>`.
+- Added Dropbox storage support (`xvc storage new dropbox`). Credentials are read from `DROPBOX_ACCESS_TOKEN` or `XVC_STORAGE_ACCESS_TOKEN_<storage_name>`. Closes #290.
+- Bump all package versions to `0.7.1-alpha.5`.
+- Update internal dependencies to match the new version.
 
 ## v0.7.1-alpha.4 (2026-07-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Xvc Changelog
 
+## Unreleased
+
+- Added Dropbox storage support (`xvc storage new dropbox`). Credentials are read from `DROPBOX_ACCESS_TOKEN` or `XVC_STORAGE_ACCESS_TOKEN_<storage_name>`.
+
 ## v0.7.1-alpha.4 (2026-07-19)
 
 - Added a KDL-based pipeline definition language (`pipeline export`/`import --format kdl`): pipelines defined as graphs, with `node` children for dependencies and `step` children for the commands that connect them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ xvc-logging → xvc-ecs → xvc-walker → xvc-config → xvc-core
 - **`core`** — `XvcRoot` (an `Arc<XvcRootInner>`) is the single repository handle passed everywhere. Re-exports all common types from the crates above. Contains hash algorithms (BLAKE3 default), `XvcPath`, `RecheckMethod`, `Diff`/`DiffStore`, and Git integration utilities.
 - **`file`** — `track`, `recheck`, `carry-in`, `copy`, `move`, `list`, `hash`, `bring`, `send`, `share`, `untrack` subcommands.
 - **`pipeline`** — Pipeline steps, dependency types (file, glob, glob-items, lines, line-items, regex, regex-items, url, param, sqlite, generic, step), DAG execution via `petgraph`. Steps run in parallel when not interdependent.
-- **`storage`** — Storage backends: local, S3/MinIO/R2/GCS/Wasabi/DigitalOcean (via `rust-s3`), rsync, rclone, generic (shell commands). Cloud features are Cargo feature-gated.
+- **`storage`** — Storage backends: local, S3/MinIO/R2/GCS/Wasabi/DigitalOcean (via `rust-s3`), Dropbox (via `reqwest`, using the Dropbox HTTP API directly), rsync, rclone, generic (shell commands). Cloud features are Cargo feature-gated.
 - **`test_helper`** — `create_directory_tree`, `generate_random_file`, `run_in_temp_dir`, `run_in_temp_git_dir`, `random_temp_dir`. Used from `xvc-mono`'s `xvc-test` integration tests.
 - **`lib`** — The `xvc` crate: binary entrypoint (`main.rs`), CLI dispatch (`cli/mod.rs`), public API re-exports (`api.rs`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,7 +5700,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xvc"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-config"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "crossbeam",
  "crossbeam-channel",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-core"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5830,7 +5830,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-ecs"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-file"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5904,7 +5904,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-logging"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "crossbeam-channel",
  "fern",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-pipeline"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5969,7 +5969,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-storage"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-test-helper"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -6041,7 +6041,7 @@ dependencies = [
 
 [[package]]
 name = "xvc-walker"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 dependencies = [
  "anyhow",
  "crossbeam",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5997,6 +5997,7 @@ dependencies = [
  "rayon",
  "regex",
  "relative-path",
+ "reqwest 0.13.4",
  "rmp",
  "rmp-serde",
  "rust-s3",

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ $ xvc file send 'my-data/training/*' --to my-storage
 Xvc [supports][xvc-s-n] [external directories][xvc-s-n-local], [rclone
 remotes][xvc-s-n-rclone], [Rsync][xvc-s-n-rsync], [AWS S3][xvc-s-n-s3], [Google
 Cloud Storage][xvc-s-n-gcs], [MinIO][xvc-s-n-minio], [Cloudflare
-R2][xvc-s-n-r2], [Wasabi][xvc-s-n-wasabi], [Digital Ocean Spaces][xvc-s-n-do].
-Please [create an issue] if you want Xvc to support another cloud storage
-service.
+R2][xvc-s-n-r2], [Wasabi][xvc-s-n-wasabi], [Digital Ocean Spaces][xvc-s-n-do],
+[Dropbox][xvc-s-n-dropbox]. Please [create an issue] if you want Xvc to
+support another cloud storage service.
 
 > 💡 Xvc also supports any command to upload/download files. If your favorite
 > service is not listed or you want to use another tool (s5cmd, rclone, etc.),
@@ -789,6 +789,7 @@ real-world conditions, it didn't go under the test of time. Please backup.
 [xvc-p-s-n]: https://docs.xvc.dev/ref/xvc-pipeline-step-new
 
 [xvc-s-n-do]: https://docs.xvc.dev/ref/xvc-storage-new-digital-ocean
+[xvc-s-n-dropbox]: https://docs.xvc.dev/ref/xvc-storage-new-dropbox
 [xvc-s-n-gcs]: https://docs.xvc.dev/ref/xvc-storage-new-gcs
 [xvc-s-n-generic]: https://docs.xvc.dev/ref/xvc-storage-new-generic
 [xvc-s-n-local]: https://docs.xvc.dev/ref/xvc-storage-new-local

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-config"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Xvc configuration management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,8 +16,8 @@ name = "xvc_config"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
-xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging" }
+xvc-walker = { version = "0.7.1-alpha.5", path = "../walker" }
 
 
 ## Cli and config

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-core"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Xvc core for common elements for all commands"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,10 +16,10 @@ name = "xvc_core"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-config = { version = "0.7.1-alpha.4", path = "../config" }
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
-xvc-ecs = { version = "0.7.1-alpha.4", path = "../ecs" }
-xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
+xvc-config = { version = "0.7.1-alpha.5", path = "../config" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging" }
+xvc-ecs = { version = "0.7.1-alpha.5", path = "../ecs" }
+xvc-walker = { version = "0.7.1-alpha.5", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -93,6 +93,6 @@ itertools = "^0.15"
 
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.5", path = "../test_helper/" }
 proptest = "^1.9"
 test-case = "^3.3"

--- a/ecs/Cargo.toml
+++ b/ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-ecs"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Entity-Component System for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_ecs"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging" }
 
 ## Serialization
 serde = { version = "^1.0", features = ["derive"] }

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-file"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "File tracking, versioning, upload and download functions for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -25,8 +25,8 @@ bench = true
 # xvc-config = { version = "0.6.17-alpha.2", path = "../config" }
 # xvc-ecs = { version = "0.6.17-alpha.2", path = "../ecs" }
 # xvc-walker = { version = "0.6.17-alpha.2", path = "../walker" }
-xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
-xvc-storage = { version = "0.7.1-alpha.4", path = "../storage", default-features = false }
+xvc-core = { version = "0.7.1-alpha.5", path = "../core" }
+xvc-storage = { version = "0.7.1-alpha.5", path = "../storage", default-features = false }
 
 
 ## Cli and config
@@ -103,5 +103,5 @@ default = []
 reflink = ["dep:reflink"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.5", path = "../test_helper/" }
 shellfn = "^0.2"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "An MLOps tool to manage data files and pipelines on top of Git"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,10 +20,10 @@ name = "xvc"
 path = "src/main.rs"
 
 [dependencies]
-xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
-xvc-file = { version = "0.7.1-alpha.4", path = "../file" }
-xvc-pipeline = { version = "0.7.1-alpha.4", path = "../pipeline" }
-xvc-storage = { version = "0.7.1-alpha.4", path = "../storage", default-features = false }
+xvc-core = { version = "0.7.1-alpha.5", path = "../core" }
+xvc-file = { version = "0.7.1-alpha.5", path = "../file" }
+xvc-pipeline = { version = "0.7.1-alpha.5", path = "../pipeline" }
+xvc-storage = { version = "0.7.1-alpha.5", path = "../storage", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive", "cargo", "unstable-ext"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -90,7 +90,7 @@ predicates = "^3.1"
 
 
 [features]
-default = ["s3", "minio", "r2", "gcs", "wasabi", "digital-ocean", "rclone"]
+default = ["s3", "minio", "r2", "gcs", "wasabi", "digital-ocean", "rclone", "dropbox"]
 # Dropped reflink from default features in 0.6.13
 reflink = ["xvc-file/reflink"]
 rclone = ["xvc-storage/rclone"]
@@ -100,6 +100,7 @@ r2 = ["xvc-storage/r2"]
 gcs = ["xvc-storage/gcs"]
 wasabi = ["xvc-storage/wasabi"]
 digital-ocean = ["xvc-storage/digital-ocean"]
+dropbox = ["xvc-storage/dropbox"]
 bundled-sqlite = ["xvc-pipeline/bundled-sqlite"]
 bundled-openssl = ["xvc-storage/bundled-openssl"]
 bundled-rclone = ["xvc-storage/bundled-rclone"]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-logging"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Logging crate for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-pipeline"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Xvc data pipeline management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,11 +20,11 @@ bundled-sqlite = ["rusqlite/bundled"]
 
 [dependencies]
 # xvc-config = { version = "0.6.17-alpha.2", path = "../config" }
-xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
+xvc-core = { version = "0.7.1-alpha.5", path = "../core" }
 # xvc-ecs = { version = "0.6.17-alpha.2", path = "../ecs" }
 # xvc-logging = { version = "0.6.17-alpha.2", path = "../logging" }
 # xvc-walker = { version = "0.6.17-alpha.2", path = "../walker" }
-xvc-file = { version = "0.7.1-alpha.4", path = "../file", default-features = false }
+xvc-file = { version = "0.7.1-alpha.5", path = "../file", default-features = false }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -104,5 +104,5 @@ itertools = "^0.15"
 derive_more = { version = "^2.1", features = ["full"] }
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.5", path = "../test_helper/" }
 test-case = "^3.3"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -88,6 +88,7 @@ tempfile = "^3.23"
 tokio = { version = "^1.48", optional = true, features = ["rt-multi-thread"] }
 rust-s3 = { version = "^0.37", optional = true }
 futures = { version = "^0.3", optional = true }
+reqwest = { version = "^0.13", optional = true, features = ["blocking", "json", "gzip"] }
 
 # On Linux we use "vendored" feature and on Windows we don't use that feature.
 openssl = { version = "^0.10", optional = true }
@@ -96,7 +97,7 @@ openssl = { version = "^0.10", optional = true }
 librclone = { version = "^0.9", optional = true }
 
 [features]
-default = ["s3", "minio", "gcs", "wasabi", "r2", "digital-ocean", "rclone"]
+default = ["s3", "minio", "gcs", "wasabi", "r2", "digital-ocean", "rclone", "dropbox"]
 async = ["rust-s3", "futures", "tokio"]
 s3 = ["async"]
 minio = ["s3"]
@@ -104,6 +105,7 @@ gcs = ["s3"]
 wasabi = ["s3"]
 r2 = ["s3"]
 digital-ocean = ["s3"]
+dropbox = ["reqwest"]
 bundled-openssl = ["openssl/vendored"]
 # rclone support
 # Uses rclone from the command line, without bundling librclone

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-storage"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Xvc remote and local storage management"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,11 +16,11 @@ name = "xvc_storage"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
-xvc-config = { version = "0.7.1-alpha.4", path = "../config" }
-xvc-core = { version = "0.7.1-alpha.4", path = "../core" }
-xvc-ecs = { version = "0.7.1-alpha.4", path = "../ecs" }
-xvc-walker = { version = "0.7.1-alpha.4", path = "../walker" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging" }
+xvc-config = { version = "0.7.1-alpha.5", path = "../config" }
+xvc-core = { version = "0.7.1-alpha.5", path = "../core" }
+xvc-ecs = { version = "0.7.1-alpha.5", path = "../ecs" }
+xvc-walker = { version = "0.7.1-alpha.5", path = "../walker" }
 
 ## Cli and config
 clap = { version = "^4.5", features = ["derive"] }
@@ -114,7 +114,7 @@ rclone = []
 bundled-rclone = ["rclone", "librclone"]
 
 [dev-dependencies]
-xvc-test-helper = { version = "0.7.1-alpha.4", path = "../test_helper/" }
+xvc-test-helper = { version = "0.7.1-alpha.5", path = "../test_helper/" }
 shellfn = "^0.2"
 
 [package.metadata.cargo-udeps.ignore]

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -104,6 +104,31 @@ pub enum Error {
 
     #[error("This storage type does not support file sharing with signed URLs")]
     StorageDoesNotSupportSignedUrls,
+
+    #[error(
+        "Access token for storage '{storage_name}' not found. Please set one of the following environment variables: {vars:?}"
+    )]
+    CloudTokenNotFound {
+        storage_name: String,
+        vars: Vec<String>,
+    },
+
+    #[cfg(feature = "dropbox")]
+    #[error("Dropbox HTTP Error: {source}")]
+    ReqwestError {
+        #[from]
+        source: reqwest::Error,
+    },
+
+    #[cfg(feature = "dropbox")]
+    #[error("Dropbox API Error: {0}")]
+    DropboxApiError(String),
+
+    #[error("JSON Error: {source}")]
+    SerdeJsonError {
+        #[from]
+        source: serde_json::Error,
+    },
 }
 
 impl<T> From<crossbeam_channel::SendError<T>> for Error

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -332,6 +332,24 @@ pub enum StorageNewSubCommand {
         #[arg(long, default_value = "")]
         storage_prefix: String,
     },
+
+    #[cfg(feature = "dropbox")]
+    /// Add a new Dropbox storage
+    ///
+    /// Reads credentials from `DROPBOX_ACCESS_TOKEN` environment variable.
+    /// Alternatively you can use `XVC_STORAGE_ACCESS_TOKEN_<storage_name>` environment variable
+    /// if you have multiple storages of this type.
+    #[command()]
+    Dropbox {
+        /// Name of the storage
+        ///
+        /// This must be unique among all storages of the project
+        #[arg(long = "name", short = 'n')]
+        name: String,
+        /// You can set a directory in Dropbox with this prefix
+        #[arg(long, default_value = "")]
+        storage_prefix: String,
+    },
 }
 
 /// Specifies a storage by either a name or a GUID.
@@ -534,6 +552,11 @@ fn cmd_storage_new(
         } => {
             storage::rsync::cmd_new_rsync(output_snd, xvc_root, name, host, port, user, storage_dir)
         }
+        #[cfg(feature = "dropbox")]
+        StorageNewSubCommand::Dropbox {
+            name,
+            storage_prefix,
+        } => storage::dropbox::cmd_new_dropbox(input, output_snd, xvc_root, name, storage_prefix),
     }
 }
 

--- a/storage/src/storage/dropbox.rs
+++ b/storage/src/storage/dropbox.rs
@@ -100,15 +100,17 @@ impl XvcDropboxStorage {
         self.storage_prefix.trim_matches('/').to_string()
     }
 
-    /// The relative storage path (no leading slash) of a cache path in the storage.
-    /// This is used to build [XvcStoragePath] values recorded in storage events.
-    fn build_storage_path(&self, cache_path: &XvcCachePath) -> XvcStoragePath {
+    /// The relative storage path (no leading slash) of a cache path in the storage:
+    /// `{storage_prefix}/{repo_guid}/{cache_path}`. This is used both as the actual Dropbox
+    /// object key and as the [XvcStoragePath] value recorded in storage events, so it must use
+    /// the same repository GUID that [XvcDropboxStorage::list] filters on.
+    fn build_storage_path(&self, xvc_root: &XvcRoot, cache_path: &XvcCachePath) -> XvcStoragePath {
         let prefix = self.storage_prefix_trimmed();
-        let guid = self.guid.to_string();
+        let xvc_guid = xvc_root.guid();
         let relative = if prefix.is_empty() {
-            format!("{guid}/{cache_path}")
+            format!("{xvc_guid}/{cache_path}")
         } else {
-            format!("{prefix}/{guid}/{cache_path}")
+            format!("{prefix}/{xvc_guid}/{cache_path}")
         };
         XvcStoragePath::from(relative)
     }
@@ -332,7 +334,7 @@ impl XvcStorageOperations for XvcDropboxStorage {
         let mut sent_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
 
         for cache_path in paths {
-            let storage_path = self.build_storage_path(cache_path);
+            let storage_path = self.build_storage_path(xvc_root, cache_path);
             let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
             let abs_cache_path = cache_path.to_absolute_path(xvc_root);
 
@@ -357,7 +359,7 @@ impl XvcStorageOperations for XvcDropboxStorage {
     fn receive(
         &self,
         output: &XvcOutputSender,
-        _xvc_root: &XvcRoot,
+        xvc_root: &XvcRoot,
         paths: &[XvcCachePath],
         _force: bool,
     ) -> Result<(XvcStorageTempDir, XvcStorageReceiveEvent)> {
@@ -365,7 +367,7 @@ impl XvcStorageOperations for XvcDropboxStorage {
         let mut received_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
 
         for cache_path in paths {
-            let storage_path = self.build_storage_path(cache_path);
+            let storage_path = self.build_storage_path(xvc_root, cache_path);
             let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
 
             match self.download(&dropbox_path) {
@@ -393,13 +395,13 @@ impl XvcStorageOperations for XvcDropboxStorage {
     fn delete(
         &self,
         output: &XvcOutputSender,
-        _xvc_root: &XvcRoot,
+        xvc_root: &XvcRoot,
         paths: &[XvcCachePath],
     ) -> Result<XvcStorageDeleteEvent> {
         let mut deleted_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
 
         for cache_path in paths {
-            let storage_path = self.build_storage_path(cache_path);
+            let storage_path = self.build_storage_path(xvc_root, cache_path);
             let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
 
             match self.delete_path(&dropbox_path) {
@@ -424,11 +426,11 @@ impl XvcStorageOperations for XvcDropboxStorage {
     fn share(
         &self,
         output: &XvcOutputSender,
-        _xvc_root: &XvcRoot,
+        xvc_root: &XvcRoot,
         path: &XvcCachePath,
         _period: std::time::Duration,
     ) -> Result<XvcStorageExpiringShareEvent> {
-        let storage_path = self.build_storage_path(path);
+        let storage_path = self.build_storage_path(xvc_root, path);
         let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
 
         let result: DbxTemporaryLinkResult = serde_json::from_value(

--- a/storage/src/storage/dropbox.rs
+++ b/storage/src/storage/dropbox.rs
@@ -1,0 +1,448 @@
+//! Dropbox remote storage implementation.
+use std::env;
+use std::fs;
+
+use regex::Regex;
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use xvc_core::R1NStore;
+use xvc_core::XvcCachePath;
+use xvc_core::XvcOutputSender;
+use xvc_core::XvcRoot;
+use xvc_core::{error, info, output};
+
+use crate::{Error, Result, XvcStorage, XvcStorageEvent};
+use crate::{XvcStorageGuid, XvcStorageOperations};
+
+use super::{
+    XVC_STORAGE_GUID_FILENAME, XvcStorageDeleteEvent, XvcStorageExpiringShareEvent,
+    XvcStorageInitEvent, XvcStorageListEvent, XvcStoragePath, XvcStorageReceiveEvent,
+    XvcStorageSendEvent, XvcStorageTempDir,
+};
+
+const DBX_RPC_URL: &str = "https://api.dropboxapi.com/2";
+const DBX_CONTENT_URL: &str = "https://content.dropboxapi.com/2";
+
+/// Dropbox temporary links (used for [XvcDropboxStorage::share]) are valid for four hours.
+/// Dropbox doesn't allow the expiration duration to be configured.
+const DBX_TEMPORARY_LINK_EXPIRATION_SECONDS: u32 = 4 * 60 * 60;
+
+/// Entry point for `xvc storage new dropbox` command.
+///
+/// Creates a new [XvcDropboxStorage], calls its [init][XvcDropboxStorage::init] to write the
+/// `.xvc-guid` file to the storage, and saves the storage record and init event in the ECS.
+pub fn cmd_new_dropbox(
+    _input: std::io::StdinLock,
+    output_snd: &XvcOutputSender,
+    xvc_root: &XvcRoot,
+    name: String,
+    storage_prefix: String,
+) -> Result<()> {
+    let mut storage = XvcDropboxStorage {
+        guid: XvcStorageGuid::new(),
+        name,
+        storage_prefix,
+    };
+
+    let init_event = storage.init(output_snd, xvc_root)?;
+
+    xvc_root.with_r1nstore_mut(|store: &mut R1NStore<XvcStorage, XvcStorageEvent>| {
+        let store_e = xvc_root.new_entity();
+        let event_e = xvc_root.new_entity();
+        store.insert(
+            store_e,
+            XvcStorage::Dropbox(storage.clone()),
+            event_e,
+            XvcStorageEvent::Init(init_event.clone()),
+        );
+        Ok(())
+    })?;
+
+    info!(output_snd, "Created Dropbox Storage: {:#?}", storage);
+
+    Ok(())
+}
+
+/// A Dropbox storage.
+#[derive(Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize)]
+pub struct XvcDropboxStorage {
+    /// The GUID of the storage.
+    pub guid: XvcStorageGuid,
+    /// The name of the storage.
+    pub name: String,
+    /// The directory in Dropbox to store the files, without leading/trailing slashes.
+    pub storage_prefix: String,
+}
+
+#[derive(Deserialize)]
+struct DbxListFolderEntry {
+    #[serde(rename = ".tag")]
+    tag: String,
+    path_lower: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DbxListFolderResult {
+    entries: Vec<DbxListFolderEntry>,
+    cursor: String,
+    has_more: bool,
+}
+
+#[derive(Deserialize)]
+struct DbxTemporaryLinkResult {
+    link: String,
+}
+
+impl XvcDropboxStorage {
+    /// Storage prefix without leading/trailing slashes.
+    fn storage_prefix_trimmed(&self) -> String {
+        self.storage_prefix.trim_matches('/').to_string()
+    }
+
+    /// The relative storage path (no leading slash) of a cache path in the storage.
+    /// This is used to build [XvcStoragePath] values recorded in storage events.
+    fn build_storage_path(&self, cache_path: &XvcCachePath) -> XvcStoragePath {
+        let prefix = self.storage_prefix_trimmed();
+        let guid = self.guid.to_string();
+        let relative = if prefix.is_empty() {
+            format!("{guid}/{cache_path}")
+        } else {
+            format!("{prefix}/{guid}/{cache_path}")
+        };
+        XvcStoragePath::from(relative)
+    }
+
+    /// Dropbox requires absolute paths, prefixed with `/`.
+    fn to_dropbox_path(relative: &str) -> String {
+        format!("/{relative}")
+    }
+
+    /// The Dropbox path of the `storage_prefix` directory. Root is represented as `""` in the
+    /// Dropbox API, not `/`.
+    fn root_dropbox_path(&self) -> String {
+        let prefix = self.storage_prefix_trimmed();
+        if prefix.is_empty() {
+            String::new()
+        } else {
+            format!("/{prefix}")
+        }
+    }
+
+    /// The Dropbox path of the `.xvc-guid` file.
+    fn guid_dropbox_path(&self) -> String {
+        let prefix = self.storage_prefix_trimmed();
+        if prefix.is_empty() {
+            Self::to_dropbox_path(XVC_STORAGE_GUID_FILENAME)
+        } else {
+            Self::to_dropbox_path(&format!("{prefix}/{XVC_STORAGE_GUID_FILENAME}"))
+        }
+    }
+
+    /// Reads the access token from `XVC_STORAGE_ACCESS_TOKEN_<name>` or `DROPBOX_ACCESS_TOKEN`
+    /// environment variables, in that order.
+    fn access_token(&self) -> Result<String> {
+        let specific_var = format!("XVC_STORAGE_ACCESS_TOKEN_{}", self.name);
+        if let Ok(token) = env::var(&specific_var) {
+            return Ok(token);
+        }
+
+        let generic_var = "DROPBOX_ACCESS_TOKEN";
+        if let Ok(token) = env::var(generic_var) {
+            return Ok(token);
+        }
+
+        Err(Error::CloudTokenNotFound {
+            storage_name: self.name.clone(),
+            vars: vec![specific_var, generic_var.to_string()],
+        })
+    }
+
+    /// Calls a Dropbox RPC endpoint (`api.dropboxapi.com`) with a JSON body and returns the
+    /// parsed JSON response.
+    fn rpc_call(&self, endpoint: &str, body: serde_json::Value) -> Result<serde_json::Value> {
+        let token = self.access_token()?;
+        let client = Client::new();
+        let response = client
+            .post(format!("{DBX_RPC_URL}/{endpoint}"))
+            .bearer_auth(token)
+            .json(&body)
+            .send()?;
+
+        let status = response.status();
+        let text = response.text()?;
+
+        if !status.is_success() {
+            return Err(Error::DropboxApiError(format!(
+                "{endpoint}: {status}: {text}"
+            )));
+        }
+
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    /// Uploads `content` to `dropbox_path`, overwriting any existing file.
+    fn upload(&self, dropbox_path: &str, content: Vec<u8>) -> Result<()> {
+        let token = self.access_token()?;
+        let client = Client::new();
+        let arg = json!({
+            "path": dropbox_path,
+            "mode": "overwrite",
+            "autorename": false,
+            "mute": true,
+        });
+
+        let response = client
+            .post(format!("{DBX_CONTENT_URL}/files/upload"))
+            .bearer_auth(token)
+            .header("Dropbox-API-Arg", arg.to_string())
+            .header("Content-Type", "application/octet-stream")
+            .body(content)
+            .send()?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text()?;
+            return Err(Error::DropboxApiError(format!(
+                "files/upload: {status}: {text}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Downloads and returns the content of `dropbox_path`.
+    fn download(&self, dropbox_path: &str) -> Result<Vec<u8>> {
+        let token = self.access_token()?;
+        let client = Client::new();
+        let arg = json!({ "path": dropbox_path });
+
+        let response = client
+            .post(format!("{DBX_CONTENT_URL}/files/download"))
+            .bearer_auth(token)
+            .header("Dropbox-API-Arg", arg.to_string())
+            .send()?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text()?;
+            return Err(Error::DropboxApiError(format!(
+                "files/download: {status}: {text}"
+            )));
+        }
+
+        Ok(response.bytes()?.to_vec())
+    }
+
+    /// Deletes `dropbox_path` from the storage.
+    fn delete_path(&self, dropbox_path: &str) -> Result<()> {
+        self.rpc_call("files/delete_v2", json!({ "path": dropbox_path }))?;
+        Ok(())
+    }
+
+    /// Recursively lists all file paths (relative, no leading slash) under `storage_prefix`.
+    fn list_all_files(&self) -> Result<Vec<String>> {
+        let mut paths = Vec::new();
+
+        let mut result: DbxListFolderResult = serde_json::from_value(self.rpc_call(
+            "files/list_folder",
+            json!({ "path": self.root_dropbox_path(), "recursive": true }),
+        )?)?;
+
+        loop {
+            for entry in result.entries {
+                if entry.tag == "file"
+                    && let Some(path_lower) = entry.path_lower
+                {
+                    paths.push(path_lower.trim_start_matches('/').to_string());
+                }
+            }
+
+            if !result.has_more {
+                break;
+            }
+
+            result = serde_json::from_value(self.rpc_call(
+                "files/list_folder/continue",
+                json!({ "cursor": result.cursor }),
+            )?)?;
+        }
+
+        Ok(paths)
+    }
+}
+
+impl XvcStorageOperations for XvcDropboxStorage {
+    /// Writes the `.xvc-guid` file to `storage_prefix` in Dropbox.
+    fn init(
+        &mut self,
+        output: &XvcOutputSender,
+        _xvc_root: &XvcRoot,
+    ) -> Result<XvcStorageInitEvent> {
+        let guid_dropbox_path = self.guid_dropbox_path();
+        self.upload(&guid_dropbox_path, self.guid.to_string().into_bytes())?;
+
+        info!(output, "Initialized Dropbox storage at {guid_dropbox_path}");
+
+        Ok(XvcStorageInitEvent {
+            guid: self.guid.clone(),
+        })
+    }
+
+    /// Lists all files in the storage that match the Xvc cache path pattern:
+    ///
+    /// {storage_prefix}/{XVC_GUID}/[a-zA-Z][0-9]/[0-9A-Fa-f]{3}/[0-9A-Fa-f]{3}/[0-9A-Fa-f]{58}/0
+    fn list(&self, _output: &XvcOutputSender, xvc_root: &XvcRoot) -> Result<XvcStorageListEvent> {
+        let xvc_guid = xvc_root.guid();
+        let prefix = self.storage_prefix_trimmed();
+        let prefix_pattern = if prefix.is_empty() {
+            String::new()
+        } else {
+            format!("{prefix}/")
+        };
+
+        let re = Regex::new(&format!(
+            "^{prefix_pattern}{xvc_guid}/{cp}/{d3}/{d3}/{d58}/0\\..*$",
+            cp = r#"[a-zA-Z][0-9]"#,
+            d3 = r#"[0-9A-Fa-f]{3}"#,
+            d58 = r#"[0-9A-Fa-f]{58}"#
+        ))
+        .unwrap();
+
+        let paths = self
+            .list_all_files()?
+            .into_iter()
+            .filter(|p| re.is_match(p))
+            .map(XvcStoragePath::from)
+            .collect();
+
+        Ok(XvcStorageListEvent {
+            guid: self.guid.clone(),
+            paths,
+        })
+    }
+
+    fn send(
+        &self,
+        output: &XvcOutputSender,
+        xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+        _force: bool,
+    ) -> Result<XvcStorageSendEvent> {
+        let mut sent_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+
+        for cache_path in paths {
+            let storage_path = self.build_storage_path(cache_path);
+            let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
+            let abs_cache_path = cache_path.to_absolute_path(xvc_root);
+
+            match fs::read(&abs_cache_path) {
+                Ok(content) => match self.upload(&dropbox_path, content) {
+                    Ok(_) => {
+                        info!(output, "{} -> {}", abs_cache_path, dropbox_path);
+                        sent_paths.push(storage_path);
+                    }
+                    Err(err) => error!(output, "{}", err),
+                },
+                Err(err) => error!(output, "{}", err),
+            }
+        }
+
+        Ok(XvcStorageSendEvent {
+            guid: self.guid.clone(),
+            paths: sent_paths,
+        })
+    }
+
+    fn receive(
+        &self,
+        output: &XvcOutputSender,
+        _xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+        _force: bool,
+    ) -> Result<(XvcStorageTempDir, XvcStorageReceiveEvent)> {
+        let temp_dir = XvcStorageTempDir::new()?;
+        let mut received_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+
+        for cache_path in paths {
+            let storage_path = self.build_storage_path(cache_path);
+            let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
+
+            match self.download(&dropbox_path) {
+                Ok(content) => {
+                    let cache_dir = temp_dir.temp_cache_dir(cache_path)?;
+                    fs::create_dir_all(&cache_dir)?;
+                    let local_path = temp_dir.temp_cache_path(cache_path)?;
+                    fs::write(&local_path, content)?;
+                    info!(output, "{} -> {}", dropbox_path, local_path);
+                    received_paths.push(storage_path);
+                }
+                Err(err) => error!(output, "{}", err),
+            }
+        }
+
+        Ok((
+            temp_dir,
+            XvcStorageReceiveEvent {
+                guid: self.guid.clone(),
+                paths: received_paths,
+            },
+        ))
+    }
+
+    fn delete(
+        &self,
+        output: &XvcOutputSender,
+        _xvc_root: &XvcRoot,
+        paths: &[XvcCachePath],
+    ) -> Result<XvcStorageDeleteEvent> {
+        let mut deleted_paths = Vec::<XvcStoragePath>::with_capacity(paths.len());
+
+        for cache_path in paths {
+            let storage_path = self.build_storage_path(cache_path);
+            let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
+
+            match self.delete_path(&dropbox_path) {
+                Ok(_) => {
+                    info!(output, "[DELETE] {}", dropbox_path);
+                    deleted_paths.push(storage_path);
+                }
+                Err(err) => error!(output, "{}", err),
+            }
+        }
+
+        Ok(XvcStorageDeleteEvent {
+            guid: self.guid.clone(),
+            paths: deleted_paths,
+        })
+    }
+
+    /// Shares a file with a Dropbox temporary link, valid for four hours.
+    ///
+    /// Dropbox doesn't support arbitrary expiration durations for temporary links, so `period`
+    /// is ignored.
+    fn share(
+        &self,
+        output: &XvcOutputSender,
+        _xvc_root: &XvcRoot,
+        path: &XvcCachePath,
+        _period: std::time::Duration,
+    ) -> Result<XvcStorageExpiringShareEvent> {
+        let storage_path = self.build_storage_path(path);
+        let dropbox_path = Self::to_dropbox_path(storage_path.as_str());
+
+        let result: DbxTemporaryLinkResult = serde_json::from_value(
+            self.rpc_call("files/get_temporary_link", json!({ "path": dropbox_path }))?,
+        )?;
+
+        info!(output, "[SHARED] {}", dropbox_path);
+        output!(output, "{}", result.link);
+
+        Ok(XvcStorageExpiringShareEvent {
+            guid: self.guid.clone(),
+            path: storage_path,
+            signed_url: result.link,
+            expiration_seconds: DBX_TEMPORARY_LINK_EXPIRATION_SECONDS,
+        })
+    }
+}

--- a/storage/src/storage/mod.rs
+++ b/storage/src/storage/mod.rs
@@ -6,6 +6,8 @@ pub mod async_common;
 
 #[cfg(feature = "digital-ocean")]
 pub mod digital_ocean;
+#[cfg(feature = "dropbox")]
+pub mod dropbox;
 pub mod event;
 #[cfg(feature = "gcs")]
 pub mod gcs;
@@ -87,6 +89,9 @@ pub enum XvcStorage {
     /// A DigitalOcean storage is a bucket in DigitalOcean
     #[cfg(feature = "digital-ocean")]
     DigitalOcean(digital_ocean::XvcDigitalOceanStorage),
+    /// A Dropbox storage is a folder in a Dropbox account
+    #[cfg(feature = "dropbox")]
+    Dropbox(dropbox::XvcDropboxStorage),
 }
 persist!(XvcStorage, "storage");
 
@@ -111,6 +116,8 @@ impl XvcStorage {
             XvcStorage::Wasabi(s) => s.name.clone(),
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(s) => s.name.clone(),
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(s) => s.name.clone(),
         }
     }
 
@@ -134,6 +141,8 @@ impl XvcStorage {
             XvcStorage::Wasabi(s) => s.guid.to_string(),
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(s) => s.guid.to_string(),
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(s) => s.guid.to_string(),
         }
     }
 
@@ -157,6 +166,8 @@ impl XvcStorage {
             XvcStorage::Wasabi(s) => s,
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(s) => s,
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(s) => s,
         }
     }
 
@@ -180,6 +191,8 @@ impl XvcStorage {
             XvcStorage::Wasabi(s) => s,
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(s) => s,
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(s) => s,
         }
     }
 }
@@ -258,6 +271,12 @@ impl std::fmt::Display for XvcStorage {
                 f,
                 "DO:      {}\t{}\t{}.{}/{}",
                 dor.name, dor.guid, dor.region, dor.bucket_name, dor.storage_prefix
+            ),
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(dbr) => write!(
+                f,
+                "Dropbox: {}\t{}\t{}",
+                dbr.name, dbr.guid, dbr.storage_prefix
             ),
         }
     }
@@ -398,6 +417,8 @@ pub fn get_storage_record(
             XvcStorage::Wasabi(r) => r.name == *n,
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(r) => r.name == *n,
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(r) => r.name == *n,
         },
         StorageIdentifier::Uuid(id) => match r {
             XvcStorage::Local(lr) => lr.guid == (*id).into(),
@@ -417,6 +438,8 @@ pub fn get_storage_record(
             XvcStorage::Wasabi(r) => r.guid == (*id).into(),
             #[cfg(feature = "digital-ocean")]
             XvcStorage::DigitalOcean(r) => r.guid == (*id).into(),
+            #[cfg(feature = "dropbox")]
+            XvcStorage::Dropbox(r) => r.guid == (*id).into(),
         },
     });
 

--- a/test_helper/Cargo.toml
+++ b/test_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-test-helper"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Test helper command for Xvc"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging/" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging/" }
 
 rand = "^0.10"
 log = "^0.4"

--- a/walker/Cargo.toml
+++ b/walker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xvc-walker"
-version = "0.7.1-alpha.4"
+version = "0.7.1-alpha.5"
 edition = "2024"
 description = "Xvc parallel file system walker with ignore features"
 authors = ["Emre Şahin <contact@emresahin.net>"]
@@ -16,7 +16,7 @@ name = "xvc_walker"
 crate-type = ["rlib"]
 
 [dependencies]
-xvc-logging = { version = "0.7.1-alpha.4", path = "../logging" }
+xvc-logging = { version = "0.7.1-alpha.5", path = "../logging" }
 # NOTE: 1.0 removed the multi-pattern Glob struct; it's reimplemented in src/glob.rs
 fast-glob = "^1.0"
 
@@ -42,7 +42,7 @@ itertools = "^0.15"
 regex = "^1.12"
 
 [dev-dependencies]
-xvc-test-helper = { path = "../test_helper/", version = "0.7.1-alpha.4" }
+xvc-test-helper = { path = "../test_helper/", version = "0.7.1-alpha.5" }
 test-case = "^3.3"
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
Implements `xvc storage new dropbox --name <NAME> --storage-prefix <PREFIX>`,
matching the CLI surface and behavior already documented and tested in
iesahin/xvc-mono#8 and #12. Talks to the Dropbox HTTP API v2 directly via
reqwest (list_folder, upload, download, delete_v2, get_temporary_link).
Credentials are read from DROPBOX_ACCESS_TOKEN or
XVC_STORAGE_ACCESS_TOKEN_<storage_name>, gated behind a new "dropbox"
Cargo feature enabled by default.